### PR TITLE
Refine chat overview interactions and background controls

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -6,7 +6,7 @@ interface ChatHeaderProps {
   agentName: string;
   agentRole: string;
   agentStatus: 'online' | 'offline' | 'busy';
-  onToggleDrawer: () => void;
+  onOpenOverview: () => void;
   onOpenSettings: () => void;
   agentAvatar: string;
 }
@@ -21,7 +21,7 @@ export function ChatHeader({
   agentName,
   agentRole,
   agentStatus,
-  onToggleDrawer,
+  onOpenOverview,
   onOpenSettings,
   agentAvatar
 }: ChatHeaderProps) {
@@ -41,7 +41,7 @@ export function ChatHeader({
       <div className="flex items-center gap-4">
         <button
           className="lg:hidden rounded-full bg-white/10 p-2 text-white/80 hover:bg-white/20 transition"
-          onClick={onToggleDrawer}
+          onClick={onOpenOverview}
         >
           <Bars3Icon className="h-5 w-5" />
         </button>

--- a/src/components/ChatTimeline.tsx
+++ b/src/components/ChatTimeline.tsx
@@ -5,22 +5,35 @@ interface ChatTimelineProps {
   chat: Chat;
   agentAvatar: string;
   userAvatar: string;
+  backgroundImage?: string;
 }
 
-export function ChatTimeline({ chat, agentAvatar, userAvatar }: ChatTimelineProps) {
+export function ChatTimeline({ chat, agentAvatar, userAvatar, backgroundImage }: ChatTimelineProps) {
   return (
-    <section className="flex-1 overflow-y-auto px-4 md:px-8 py-6 space-y-6">
-      {chat.messages.map((message) => (
-        <ChatMessageBubble
-          key={message.id}
-          message={message}
-          isAgent={message.author === 'agent'}
-          agentAvatar={agentAvatar}
-          userAvatar={userAvatar}
+    <section className="relative flex-1 overflow-hidden">
+      {backgroundImage && (
+        <div
+          className="pointer-events-none absolute inset-0 opacity-40"
+          style={{
+            backgroundImage: `url(${backgroundImage})`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center'
+          }}
         />
-      ))}
-      <div className="rounded-3xl border border-dashed border-white/10 px-6 py-5 text-sm text-white/40">
-        Nächste Antwort des Agents erscheint hier – verfolge die Live-Streaming Ausgabe des Webhooks in Echtzeit.
+      )}
+      <div className="relative h-full overflow-y-auto px-4 py-6 md:px-8 space-y-6">
+        {chat.messages.map((message) => (
+          <ChatMessageBubble
+            key={message.id}
+            message={message}
+            isAgent={message.author === 'agent'}
+            agentAvatar={agentAvatar}
+            userAvatar={userAvatar}
+          />
+        ))}
+        <div className="rounded-3xl border border-dashed border-white/10 px-6 py-5 text-sm text-white/60 backdrop-blur-sm bg-black/20">
+          Nächste Antwort des Agents erscheint hier – verfolge die Live-Streaming Ausgabe des Webhooks in Echtzeit.
+        </div>
       </div>
     </section>
   );

--- a/src/components/MobileNavBar.tsx
+++ b/src/components/MobileNavBar.tsx
@@ -7,15 +7,15 @@ import {
 interface MobileNavBarProps {
   onNewChat: () => void;
   onOpenSettings: () => void;
-  onToggleDrawer: () => void;
+  onToggleOverview: () => void;
 }
 
-export function MobileNavBar({ onNewChat, onOpenSettings, onToggleDrawer }: MobileNavBarProps) {
+export function MobileNavBar({ onNewChat, onOpenSettings, onToggleOverview }: MobileNavBarProps) {
   return (
     <nav className="lg:hidden fixed inset-x-0 bottom-0 z-30 border-t border-white/10 bg-[#141414]/95 backdrop-blur-xl">
       <div className="mx-auto flex max-w-3xl items-center justify-around px-6 py-3 text-white/70">
         <button
-          onClick={onToggleDrawer}
+          onClick={onToggleOverview}
           className="flex flex-col items-center text-xs font-medium gap-1"
         >
           <Squares2X2Icon className="h-6 w-6" />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,7 +9,7 @@ interface SidebarProps {
   onChatSelect: (chatId: string) => void;
   onNewChat: () => void;
   onOpenSettings: () => void;
-  onToggleDrawer: () => void;
+  onShowOverview: () => void;
 }
 
 export function Sidebar({
@@ -18,7 +18,7 @@ export function Sidebar({
   onChatSelect,
   onNewChat,
   onOpenSettings,
-  onToggleDrawer
+  onShowOverview
 }: SidebarProps) {
   const chatsByFolder = useMemo(() => {
     const grouped = chats.reduce<Record<string, Chat[]>>((acc, chat) => {
@@ -39,7 +39,7 @@ export function Sidebar({
             <h2 className="text-xl font-semibold text-white">AI Training Studio</h2>
           </div>
           <button
-            onClick={onToggleDrawer}
+            onClick={onShowOverview}
             className="px-3 py-2 text-xs font-medium rounded-full bg-white/10 text-white/80 hover:bg-white/20 transition"
           >
             Übersicht


### PR DESCRIPTION
## Summary
- make the chat overview collapsible by folder with rename/delete actions and in-panel folder creation, plus a mobile overlay experience
- add controls to upload or clear a custom chat background image and display it behind the conversation feed
- update navigation touchpoints to open the redesigned overview from the header, sidebar, and mobile navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdd0d1c1e48324b62bd8d791e6bb7c