### PR TITLE
Update agent greeting to use user name

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -118,6 +118,11 @@ export function ChatPage() {
 
   const handleNewChat = () => {
     const timestamp = new Date();
+    const userName = settings.profileName?.trim();
+    const greeting = userName
+      ? `Hallo ${userName}! Wie kann ich dir heute helfen?`
+      : 'Hallo! Wie kann ich dir heute helfen?';
+
     const newChat: Chat = {
       id: crypto.randomUUID(),
       name: 'Neuer Chat',
@@ -130,8 +135,7 @@ export function ChatPage() {
         {
           id: crypto.randomUUID(),
           author: 'agent',
-          content:
-            'Hallo! Ich bin bereit, deinen Flow zu konfigurieren. Teile mir deine Ziele oder den Webhook-Endpunkt mit.',
+          content: greeting,
           timestamp: timestamp.toLocaleTimeString('de-DE', {
             hour: '2-digit',
             minute: '2-digit'


### PR DESCRIPTION
## Summary
- personalize the initial agent greeting to address the user by their configured name

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d12f0d8864832496e0aab160811c5d