### PR TITLE
Add Supabase authentication and admin management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.1.3",
+        "@supabase/supabase-js": "^2.57.4",
         "clsx": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1161,6 +1162,80 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.6",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.1"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1213,6 +1288,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1239,6 +1329,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2905,6 +3004,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -2925,6 +3030,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -3022,6 +3133,22 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -3136,6 +3263,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.3",
+    "@supabase/supabase-js": "^2.57.4",
     "clsx": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { SettingsPage } from './pages/SettingsPage';
 import { LoginPage } from './pages/LoginPage';
 import { RegisterPage } from './pages/RegisterPage';
 import { AdminDashboardPage } from './pages/AdminDashboardPage';
+import { LandingPage } from './pages/LandingPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { AdminRoute } from './components/AdminRoute';
 import { useAuth } from './hooks/useAuth';
@@ -13,16 +14,17 @@ function App() {
 
   return (
     <Routes>
+      <Route path="/" element={<LandingPage />} />
       <Route
         path="/login"
-        element={user ? <Navigate to="/" replace /> : <LoginPage />}
+        element={user ? <Navigate to="/chat" replace /> : <LoginPage />}
       />
       <Route
         path="/register"
-        element={user ? <Navigate to="/" replace /> : <RegisterPage />}
+        element={user ? <Navigate to="/chat" replace /> : <RegisterPage />}
       />
       <Route
-        path="/"
+        path="/chat"
         element={
           <ProtectedRoute>
             <ChatPage />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,52 @@
 import { Route, Routes, Navigate } from 'react-router-dom';
 import { ChatPage } from './pages/ChatPage';
 import { SettingsPage } from './pages/SettingsPage';
+import { LoginPage } from './pages/LoginPage';
+import { RegisterPage } from './pages/RegisterPage';
+import { AdminDashboardPage } from './pages/AdminDashboardPage';
+import { ProtectedRoute } from './components/ProtectedRoute';
+import { AdminRoute } from './components/AdminRoute';
+import { useAuth } from './hooks/useAuth';
 
 function App() {
+  const { user } = useAuth();
+
   return (
     <Routes>
-      <Route path="/" element={<ChatPage />} />
-      <Route path="/settings" element={<SettingsPage />} />
+      <Route
+        path="/login"
+        element={user ? <Navigate to="/" replace /> : <LoginPage />}
+      />
+      <Route
+        path="/register"
+        element={user ? <Navigate to="/" replace /> : <RegisterPage />}
+      />
+      <Route
+        path="/"
+        element={
+          <ProtectedRoute>
+            <ChatPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/settings"
+        element={
+          <ProtectedRoute>
+            <SettingsPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/admin"
+        element={
+          <ProtectedRoute>
+            <AdminRoute>
+              <AdminDashboardPage />
+            </AdminRoute>
+          </ProtectedRoute>
+        }
+      />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );

--- a/src/components/AdminRoute.tsx
+++ b/src/components/AdminRoute.tsx
@@ -1,0 +1,20 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+export const AdminRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { profile, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-100">
+        <span className="animate-pulse text-lg">Prüfe Berechtigungen…</span>
+      </div>
+    );
+  }
+
+  if (!profile?.admin) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/src/components/AdminRoute.tsx
+++ b/src/components/AdminRoute.tsx
@@ -13,7 +13,7 @@ export const AdminRoute: React.FC<{ children: React.ReactNode }> = ({ children }
   }
 
   if (!profile?.admin) {
-    return <Navigate to="/" replace />;
+    return <Navigate to="/chat" replace />;
   }
 
   return <>{children}</>;

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,37 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+const AccessRevoked: React.FC = () => (
+  <div className="flex min-h-screen items-center justify-center bg-slate-950 px-4 text-center text-slate-100">
+    <div className="max-w-md space-y-4">
+      <h1 className="text-2xl font-semibold">Zugriff gesperrt</h1>
+      <p className="text-slate-300">
+        Dein Konto wurde deaktiviert. Bitte wende dich an den Administrator, wenn du glaubst, dass es sich um einen Fehler
+        handelt.
+      </p>
+    </div>
+  </div>
+);
+
+export const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user, loading, profile } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-100">
+        <span className="animate-pulse text-lg">Wird geladen…</span>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  if (profile && profile.access_granted === false) {
+    return <AccessRevoked />;
+  }
+
+  return <>{children}</>;
+};

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,180 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+import { supabase } from '../utils/supabaseClient';
+
+type Profile = {
+  id: string;
+  email: string | null;
+  full_name: string | null;
+  admin: boolean;
+  access_granted: boolean | null;
+};
+
+type AuthContextValue = {
+  session: Session | null;
+  user: User | null;
+  profile: Profile | null;
+  loading: boolean;
+  signIn: (credentials: { email: string; password: string }) => Promise<{ error?: string }>;
+  signUp: (payload: { email: string; password: string; fullName?: string }) => Promise<{ error?: string }>;
+  signOut: () => Promise<void>;
+  refreshProfile: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+async function fetchProfile(userId: string): Promise<Profile | null> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('id, email, full_name, admin, access_granted')
+    .eq('id', userId)
+    .single();
+
+  if (error) {
+    console.error('Failed to load profile', error);
+    return null;
+  }
+
+  return data as Profile;
+}
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadInitialSession = async () => {
+      const {
+        data: { session: initialSession },
+        error,
+      } = await supabase.auth.getSession();
+
+      if (!isMounted) return;
+
+      if (error) {
+        console.error('Failed to get session', error);
+      }
+
+      setSession(initialSession);
+      setUser(initialSession?.user ?? null);
+
+      if (initialSession?.user) {
+        const profileData = await fetchProfile(initialSession.user.id);
+        if (isMounted) {
+          setProfile(profileData);
+        }
+      }
+
+      if (isMounted) {
+        setLoading(false);
+      }
+    };
+
+    loadInitialSession();
+
+    const { data: subscription } = supabase.auth.onAuthStateChange(async (_event, nextSession) => {
+      setSession(nextSession);
+      setUser(nextSession?.user ?? null);
+
+      if (nextSession?.user) {
+        setLoading(true);
+        const profileData = await fetchProfile(nextSession.user.id);
+        setProfile(profileData);
+        setLoading(false);
+      } else {
+        setProfile(null);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+      subscription.subscription.unsubscribe();
+    };
+  }, []);
+
+  const refreshProfile = useCallback(async () => {
+    if (!user) return;
+    const profileData = await fetchProfile(user.id);
+    setProfile(profileData);
+  }, [user]);
+
+  const signIn = useCallback(async ({ email, password }: { email: string; password: string }) => {
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      return { error: error.message };
+    }
+    return {};
+  }, []);
+
+  const signUp = useCallback(
+    async ({ email, password, fullName }: { email: string; password: string; fullName?: string }) => {
+      const { data, error } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          data: {
+            full_name: fullName,
+          },
+        },
+      });
+
+      if (error) {
+        return { error: error.message };
+      }
+
+      const newUser = data.user;
+      if (newUser) {
+        const { error: profileError } = await supabase.from('profiles').upsert({
+          id: newUser.id,
+          email: newUser.email,
+          full_name: fullName ?? null,
+          admin: false,
+          access_granted: true,
+        });
+
+        if (profileError) {
+          console.error('Failed to upsert profile', profileError);
+          return { error: 'Registrierung erfolgreich, aber Profil konnte nicht gespeichert werden.' };
+        }
+
+        await refreshProfile();
+      }
+
+      return {};
+    },
+    [refreshProfile]
+  );
+
+  const signOut = useCallback(async () => {
+    await supabase.auth.signOut();
+    setProfile(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      session,
+      user,
+      profile,
+      loading,
+      signIn,
+      signUp,
+      signOut,
+      refreshProfile,
+    }),
+    [session, user, profile, loading, signIn, signUp, signOut, refreshProfile]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuthContext = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuthContext must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,5 @@
+import { useAuthContext } from '../context/AuthContext';
+
+export const useAuth = () => {
+  return useAuthContext();
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App';
 import './styles/global.css';
 import { loadAgentSettings } from './utils/storage';
 import { applyColorScheme } from './utils/theme';
+import { AuthProvider } from './context/AuthContext';
 
 if (typeof window !== 'undefined') {
   const initialSettings = loadAgentSettings();
@@ -14,7 +15,9 @@ if (typeof window !== 'undefined') {
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/AdminDashboardPage.tsx
+++ b/src/pages/AdminDashboardPage.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { supabase } from '../utils/supabaseClient';
+import { useAuth } from '../hooks/useAuth';
+
+type ManagedUser = {
+  id: string;
+  email: string | null;
+  full_name: string | null;
+  admin: boolean;
+  access_granted: boolean | null;
+  agentCount: number;
+};
+
+export const AdminDashboardPage: React.FC = () => {
+  const { profile, user, signOut } = useAuth();
+  const [users, setUsers] = useState<ManagedUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [updatingUserId, setUpdatingUserId] = useState<string | null>(null);
+
+  const fetchUsers = async () => {
+    setLoading(true);
+    setError(null);
+
+    const { data, error: profilesError } = await supabase
+      .from('profiles')
+      .select('id, email, full_name, admin, access_granted');
+
+    if (profilesError) {
+      console.error(profilesError);
+      setError('Nutzerdaten konnten nicht geladen werden.');
+      setLoading(false);
+      return;
+    }
+
+    const userRows = data ?? [];
+
+    const usersWithCounts: ManagedUser[] = [];
+
+    for (const row of userRows) {
+      const { count, error: countError } = await supabase
+        .from('agents')
+        .select('*', { count: 'exact', head: true })
+        .eq('created_by', row.id);
+
+      if (countError) {
+        console.warn('Konnte Agent-Anzahl nicht ermitteln', countError);
+      }
+
+      usersWithCounts.push({
+        id: row.id as string,
+        email: row.email as string | null,
+        full_name: row.full_name as string | null,
+        admin: Boolean(row.admin),
+        access_granted: (row.access_granted as boolean | null) ?? null,
+        agentCount: count ?? 0,
+      });
+    }
+
+    setUsers(usersWithCounts);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const handleToggleAccess = async (managedUser: ManagedUser) => {
+    setUpdatingUserId(managedUser.id);
+    const nextValue = !(managedUser.access_granted ?? true);
+
+    const { error: updateError } = await supabase
+      .from('profiles')
+      .update({ access_granted: nextValue })
+      .eq('id', managedUser.id);
+
+    if (updateError) {
+      console.error(updateError);
+      setError('Zugriff konnte nicht aktualisiert werden.');
+      setUpdatingUserId(null);
+      return;
+    }
+
+    setUsers((prev) =>
+      prev.map((entry) =>
+        entry.id === managedUser.id
+          ? {
+              ...entry,
+              access_granted: nextValue,
+            }
+          : entry
+      )
+    );
+
+    if (managedUser.id === user?.id) {
+      // Wenn der Admin sich selbst den Zugriff entzieht, sofort Profil aktualisieren
+      await fetchUsers();
+    }
+
+    setUpdatingUserId(null);
+  };
+
+  const sortedUsers = useMemo(() => {
+    return [...users].sort((a, b) => {
+      if (a.admin && !b.admin) return -1;
+      if (!a.admin && b.admin) return 1;
+      const nameA = (a.full_name ?? a.email ?? '').toLowerCase();
+      const nameB = (b.full_name ?? b.email ?? '').toLowerCase();
+      return nameA.localeCompare(nameB);
+    });
+  }, [users]);
+
+  return (
+    <div className="min-h-screen bg-[#101010] text-white">
+      <header className="border-b border-white/10 bg-[#161616]/80 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-6 lg:px-12">
+          <div>
+            <h1 className="text-2xl font-semibold">Admin-Dashboard</h1>
+            <p className="text-sm text-white/60">Verwalte Benutzerzugänge und Agent-Aktivität.</p>
+          </div>
+          <nav className="flex items-center gap-3 text-sm text-white/70">
+            <Link to="/" className="rounded-full border border-white/10 px-4 py-2 hover:bg-white/10">
+              Zum Chat
+            </Link>
+            <button
+              onClick={() => signOut()}
+              className="rounded-full border border-white/10 px-4 py-2 hover:bg-white/10"
+            >
+              Abmelden
+            </button>
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-6xl px-4 py-12 lg:px-12">
+        {profile ? (
+          <div className="mb-8 rounded-2xl border border-white/10 bg-slate-900/60 p-6">
+            <p className="text-sm text-white/60">Angemeldet als</p>
+            <p className="text-lg font-semibold">{profile.full_name ?? profile.email ?? 'Admin'}</p>
+            <p className="text-sm text-emerald-400">Administrator</p>
+          </div>
+        ) : null}
+
+        <div className="rounded-3xl border border-white/10 bg-[#161616]/80 p-6 shadow-[0_0_80px_rgba(76,29,149,0.18)] backdrop-blur-xl">
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-xl font-semibold">Benutzer</h2>
+            <button
+              onClick={fetchUsers}
+              className="rounded-full border border-white/10 px-4 py-2 text-sm text-white/70 hover:bg-white/10"
+            >
+              Aktualisieren
+            </button>
+          </div>
+
+          {error ? <p className="mt-4 text-sm text-red-400">{error}</p> : null}
+
+          {loading ? (
+            <div className="mt-8 flex items-center justify-center text-white/70">Lade Benutzer…</div>
+          ) : (
+            <div className="mt-6 overflow-x-auto">
+              <table className="min-w-full divide-y divide-white/10 text-left text-sm">
+                <thead className="text-xs uppercase text-white/50">
+                  <tr>
+                    <th className="px-4 py-3">Name</th>
+                    <th className="px-4 py-3">E-Mail</th>
+                    <th className="px-4 py-3">Rolle</th>
+                    <th className="px-4 py-3">Agenten</th>
+                    <th className="px-4 py-3 text-right">Zugriff</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/5 text-white/80">
+                  {sortedUsers.map((entry) => (
+                    <tr key={entry.id} className="transition hover:bg-white/5">
+                      <td className="px-4 py-3">
+                        <div className="font-medium">{entry.full_name ?? '—'}</div>
+                      </td>
+                      <td className="px-4 py-3">{entry.email ?? '—'}</td>
+                      <td className="px-4 py-3">
+                        {entry.admin ? (
+                          <span className="rounded-full bg-indigo-500/20 px-2 py-1 text-xs font-semibold text-indigo-300">
+                            Admin
+                          </span>
+                        ) : (
+                          <span className="rounded-full bg-white/10 px-2 py-1 text-xs">User</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">{entry.agentCount}</td>
+                      <td className="px-4 py-3 text-right">
+                        {entry.admin ? (
+                          <span className="text-xs text-emerald-400">Immer aktiv</span>
+                        ) : (
+                          <button
+                            onClick={() => handleToggleAccess(entry)}
+                            disabled={updatingUserId === entry.id}
+                            className="rounded-full border border-white/10 px-3 py-1 text-xs font-semibold text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed"
+                          >
+                            {entry.access_granted === false ? 'Aktivieren' : 'Deaktivieren'}
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};

--- a/src/pages/AdminDashboardPage.tsx
+++ b/src/pages/AdminDashboardPage.tsx
@@ -120,7 +120,7 @@ export const AdminDashboardPage: React.FC = () => {
             <p className="text-sm text-white/60">Verwalte Benutzerzugänge und Agent-Aktivität.</p>
           </div>
           <nav className="flex items-center gap-3 text-sm text-white/70">
-            <Link to="/" className="rounded-full border border-white/10 px-4 py-2 hover:bg-white/10">
+            <Link to="/chat" className="rounded-full border border-white/10 px-4 py-2 hover:bg-white/10">
               Zum Chat
             </Link>
             <button

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,0 +1,56 @@
+import { Link, Navigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+export const LandingPage: React.FC = () => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-100">
+        <span className="animate-pulse text-lg">Wird geladen…</span>
+      </div>
+    );
+  }
+
+  if (user) {
+    return <Navigate to="/chat" replace />;
+  }
+
+  return (
+    <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-slate-950 px-4 py-16 text-slate-100">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.35),_transparent_65%)]" aria-hidden />
+      <div className="relative z-10 w-full max-w-2xl space-y-8 text-center">
+        <header className="space-y-4">
+          <span className="inline-flex rounded-full bg-slate-900/70 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-300">
+            Willkommen bei deinem Agentenstudio
+          </span>
+          <h1 className="text-3xl font-semibold sm:text-4xl">
+            Melde dich an oder erstelle ein Konto, um deine Agents zu steuern.
+          </h1>
+          <p className="text-slate-300">
+            Verwalte deine Unterhaltungen, passe deine Agenten an und teile Zugänge mit deinem Team.
+          </p>
+        </header>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Link
+            to="/login"
+            className="inline-flex items-center justify-center rounded-xl border border-indigo-400/60 bg-indigo-500/90 px-6 py-4 text-lg font-semibold text-white shadow-lg shadow-indigo-900/30 transition hover:bg-indigo-400"
+          >
+            Einloggen
+          </Link>
+          <Link
+            to="/register"
+            className="inline-flex items-center justify-center rounded-xl border border-slate-700 bg-slate-900/70 px-6 py-4 text-lg font-semibold text-slate-100 shadow-lg shadow-slate-900/40 transition hover:border-indigo-400 hover:text-white"
+          >
+            Registrieren
+          </Link>
+        </div>
+
+        <p className="text-sm text-slate-400">
+          Registrierungen sind geöffnet. Sobald du eingeloggt bist, kannst du sofort loslegen.
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -31,7 +31,7 @@ export const LoginPage: React.FC = () => {
       return;
     }
 
-    const redirectTo = state?.from?.pathname ?? '/';
+    const redirectTo = state?.from?.pathname ?? '/chat';
     navigate(redirectTo, { replace: true });
   };
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,93 @@
+import { FormEvent, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+type LocationState = {
+  from?: {
+    pathname: string;
+  };
+};
+
+export const LoginPage: React.FC = () => {
+  const { signIn } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = location.state as LocationState | null;
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const { error: signInError } = await signIn({ email, password });
+    setLoading(false);
+
+    if (signInError) {
+      setError(signInError);
+      return;
+    }
+
+    const redirectTo = state?.from?.pathname ?? '/';
+    navigate(redirectTo, { replace: true });
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-950 px-4">
+      <div className="w-full max-w-md rounded-2xl bg-slate-900/70 p-8 shadow-xl shadow-slate-900/40">
+        <h1 className="text-2xl font-semibold text-white">Willkommen zurück</h1>
+        <p className="mt-2 text-sm text-slate-300">Melde dich mit deinen Zugangsdaten an.</p>
+
+        <form onSubmit={handleSubmit} className="mt-8 space-y-6">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-slate-200">
+              E-Mail-Adresse
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950/60 px-4 py-3 text-white focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-slate-200">
+              Passwort
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950/60 px-4 py-3 text-white focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+            />
+          </div>
+
+          {error ? <p className="text-sm text-red-400">{error}</p> : null}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="flex w-full items-center justify-center rounded-lg bg-indigo-500 px-4 py-3 font-semibold text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:bg-indigo-400/60"
+          >
+            {loading ? 'Anmeldung…' : 'Einloggen'}
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-slate-300">
+          Noch keinen Zugang?{' '}
+          <Link to="/register" className="font-medium text-indigo-400 hover:text-indigo-300">
+            Jetzt registrieren
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,0 +1,106 @@
+import { FormEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+export const RegisterPage: React.FC = () => {
+  const { signUp } = useAuth();
+  const navigate = useNavigate();
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    setMessage(null);
+
+    const { error: signUpError } = await signUp({ email, password, fullName });
+    setLoading(false);
+
+    if (signUpError) {
+      setError(signUpError);
+      return;
+    }
+
+    setMessage('Registrierung erfolgreich! Du kannst dich jetzt anmelden.');
+    setTimeout(() => {
+      navigate('/login');
+    }, 1200);
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-950 px-4">
+      <div className="w-full max-w-md rounded-2xl bg-slate-900/70 p-8 shadow-xl shadow-slate-900/40">
+        <h1 className="text-2xl font-semibold text-white">Konto erstellen</h1>
+        <p className="mt-2 text-sm text-slate-300">Registriere dich, um den Agent zu verwenden.</p>
+
+        <form onSubmit={handleSubmit} className="mt-8 space-y-6">
+          <div>
+            <label htmlFor="fullName" className="block text-sm font-medium text-slate-200">
+              Name
+            </label>
+            <input
+              id="fullName"
+              type="text"
+              value={fullName}
+              onChange={(event) => setFullName(event.target.value)}
+              placeholder="Max Mustermann"
+              className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950/60 px-4 py-3 text-white focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-slate-200">
+              E-Mail-Adresse
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950/60 px-4 py-3 text-white focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-slate-200">
+              Passwort
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              minLength={6}
+              required
+              className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950/60 px-4 py-3 text-white focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+            />
+          </div>
+
+          {error ? <p className="text-sm text-red-400">{error}</p> : null}
+          {message ? <p className="text-sm text-emerald-400">{message}</p> : null}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="flex w-full items-center justify-center rounded-lg bg-indigo-500 px-4 py-3 font-semibold text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:bg-indigo-400/60"
+          >
+            {loading ? 'Registriere…' : 'Registrieren'}
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-slate-300">
+          Bereits registriert?{' '}
+          <Link to="/login" className="font-medium text-indigo-400 hover:text-indigo-300">
+            Zum Login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -10,9 +10,11 @@ import { loadAgentSettings, saveAgentSettings } from '../utils/storage';
 import { applyColorScheme } from '../utils/theme';
 import { sendWebhookMessage } from '../utils/webhook';
 import { prepareImageForStorage } from '../utils/image';
+import { useAuth } from '../hooks/useAuth';
 
 export function SettingsPage() {
   const navigate = useNavigate();
+  const { signOut } = useAuth();
   const [settings, setSettings] = useState<AgentSettings>(() => loadAgentSettings());
   const profileAvatarInputRef = useRef<HTMLInputElement | null>(null);
   const agentAvatarInputRef = useRef<HTMLInputElement | null>(null);
@@ -188,13 +190,23 @@ export function SettingsPage() {
   return (
     <div className="min-h-screen bg-[#101010] text-white">
       <div className="mx-auto max-w-6xl px-4 py-8 lg:px-12">
-        <button
-          onClick={() => navigate(-1)}
-          className="mb-8 inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/60 hover:bg-white/10"
-        >
-          <ArrowLeftIcon className="h-5 w-5" />
-          Zurück zum Chat
-        </button>
+        <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <button
+            onClick={() => navigate(-1)}
+            className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/60 hover:bg-white/10"
+          >
+            <ArrowLeftIcon className="h-5 w-5" />
+            Zurück zum Chat
+          </button>
+          <button
+            onClick={async () => {
+              await signOut();
+            }}
+            className="inline-flex items-center justify-center rounded-full border border-white/10 px-4 py-2 text-sm text-white/70 transition hover:bg-white/10"
+          >
+            Abmelden
+          </button>
+        </div>
 
         <header className="flex flex-col gap-6 rounded-3xl border border-white/10 bg-[#161616]/80 p-8 shadow-[0_0_80px_rgba(250,207,57,0.08)] backdrop-blur-xl md:flex-row md:items-center md:justify-between">
           <div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -192,7 +192,7 @@ export function SettingsPage() {
       <div className="mx-auto max-w-6xl px-4 py-8 lg:px-12">
         <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <button
-            onClick={() => navigate(-1)}
+            onClick={() => navigate('/chat')}
             className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/60 hover:bg-white/10"
           >
             <ArrowLeftIcon className="h-5 w-5" />

--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase configuration. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your environment.');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- add Supabase client, authentication context, and route guards to protect the chat behind login
- implement email/password login & registration pages and wrap the existing app with the auth provider
- build an admin dashboard to manage user access and view agent counts, plus expose sign-out actions in the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1332fbc708324b6d2d042ce9a786e