### PR TITLE
Add option to delete agents from profile management

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -34,6 +34,7 @@ interface AuthContextValue {
   toggleUserActive: (userId: string, nextActive: boolean) => void;
   addAgent: (agent: AgentDraft) => void;
   updateAgent: (agentId: string, updates: AgentUpdatePayload) => void;
+  removeAgent: (agentId: string) => void;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -227,6 +228,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [currentUser, persistUsers, users]
   );
 
+  const removeAgent = useCallback(
+    (agentId: string) => {
+      if (!currentUser) {
+        return;
+      }
+
+      const nextUsers = users.map((user) =>
+        user.id === currentUser.id
+          ? {
+              ...user,
+              agents: user.agents.filter((agent) => agent.id !== agentId)
+            }
+          : user
+      );
+
+      persistUsers(nextUsers);
+    },
+    [currentUser, persistUsers, users]
+  );
+
   const toggleUserActive = useCallback(
     (userId: string, nextActive: boolean) => {
       const nextUsers = users.map((user) =>
@@ -257,7 +278,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       updateProfile,
       toggleUserActive,
       addAgent,
-      updateAgent
+      updateAgent,
+      removeAgent
     }),
     [
       addAgent,
@@ -266,6 +288,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       logout,
       register,
       toggleUserActive,
+      removeAgent,
       updateAgent,
       updateProfile,
       users

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -5,6 +5,7 @@ import {
   CheckCircleIcon,
   Cog6ToothIcon,
   PlusCircleIcon,
+  TrashIcon,
   XCircleIcon,
   XMarkIcon
 } from '@heroicons/react/24/outline';
@@ -38,7 +39,7 @@ const createEmptyAgentForm = (): AgentFormState => ({
 });
 
 export function ProfilePage() {
-  const { currentUser, users, updateProfile, toggleUserActive, logout, addAgent, updateAgent } = useAuth();
+  const { currentUser, users, updateProfile, toggleUserActive, logout, addAgent, updateAgent, removeAgent } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
   const [name, setName] = useState(currentUser?.name ?? '');
@@ -152,6 +153,17 @@ export function ProfilePage() {
     setAgentError(null);
     setAgentForm(createEmptyAgentForm());
     resetAgentWebhookTest();
+  };
+
+  const handleDeleteAgent = (agentId: string) => {
+    if (typeof window !== 'undefined') {
+      const shouldDelete = window.confirm('Möchtest du diesen Agent wirklich löschen?');
+      if (!shouldDelete) {
+        return;
+      }
+    }
+
+    removeAgent(agentId);
   };
 
   const handleAgentAvatarUpload = async (file: File | null) => {
@@ -392,6 +404,14 @@ export function ProfilePage() {
                 >
                   <Cog6ToothIcon className="h-4 w-4" />
                   Konfigurieren
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleDeleteAgent(agent.id)}
+                  className="inline-flex items-center gap-2 rounded-full border border-red-500/40 px-5 py-2 text-xs font-semibold text-red-400 transition hover:border-red-400 hover:bg-red-500/10 hover:text-red-200"
+                >
+                  <TrashIcon className="h-4 w-4" />
+                  Agent löschen
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add support in the auth context for removing an agent from the current user
- surface a delete action under the configure button in the profile page with a confirmation prompt

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d16b93bc148324a82281b8b0cfc398