### PR TITLE
Stop requiring Supabase agents table for auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://tlkynjfknlulwijbgsne.supabase.co
+VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY=sb_publishable_vfedJSTC8HOHNUR_HlX7lQ_pjqfewoS

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.1.3",
+        "@supabase/supabase-js": "^2.57.4",
         "clsx": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1161,6 +1162,80 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.6",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.1"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1213,6 +1288,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1239,6 +1329,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2905,6 +3004,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -2925,6 +3030,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -3022,6 +3133,22 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -3136,6 +3263,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.3",
+    "@supabase/supabase-js": "^2.57.4",
     "clsx": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -2,8 +2,18 @@ import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 export function RequireAuth() {
-  const { currentUser } = useAuth();
+  const { currentUser, isLoading } = useAuth();
   const location = useLocation();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#0b0b0b] px-4">
+        <div className="rounded-3xl border border-white/10 bg-[#151515] px-6 py-4 text-center text-white shadow-glow">
+          <p className="text-sm text-white/70">Authentifizierung wird geladen …</p>
+        </div>
+      </div>
+    );
+  }
 
   if (!currentUser) {
     return <Navigate to="/login" replace state={{ from: location }} />;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -2,10 +2,12 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
   type ReactNode
 } from 'react';
+import { supabase } from '../utils/supabase';
 import {
   AgentDraft,
   AgentProfile,
@@ -13,93 +15,196 @@ import {
   AuthCredentials,
   AuthUser,
   ProfileUpdatePayload,
-  RegistrationPayload
+  RegistrationPayload,
+  UserRole
 } from '../types/auth';
-import {
-  loadCurrentUserId,
-  loadStoredUsers,
-  saveCurrentUserId,
-  saveStoredUsers,
-  StoredUser,
-  toAuthUser
-} from '../utils/authStorage';
 
 interface AuthContextValue {
   currentUser: AuthUser | null;
   users: AuthUser[];
+  isLoading: boolean;
   login: (credentials: AuthCredentials) => Promise<void>;
   register: (payload: RegistrationPayload) => Promise<void>;
-  logout: () => void;
-  updateProfile: (updates: ProfileUpdatePayload) => void;
-  toggleUserActive: (userId: string, nextActive: boolean) => void;
-  addAgent: (agent: AgentDraft) => void;
-  updateAgent: (agentId: string, updates: AgentUpdatePayload) => void;
-  removeAgent: (agentId: string) => void;
+  logout: () => Promise<void>;
+  updateProfile: (updates: ProfileUpdatePayload) => Promise<void>;
+  toggleUserActive: (userId: string, nextActive: boolean) => Promise<void>;
+  addAgent: (agent: AgentDraft) => Promise<void>;
+  updateAgent: (agentId: string, updates: AgentUpdatePayload) => Promise<void>;
+  removeAgent: (agentId: string) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
-const createUserFromRegistration = (payload: RegistrationPayload): StoredUser => ({
-  id:
-    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-      ? crypto.randomUUID()
-      : `user-${Math.random().toString(36).slice(2, 10)}`,
-  name: payload.name.trim(),
-  email: payload.email.toLowerCase(),
-  password: payload.password,
-  role: 'user',
-  isActive: true,
-  avatarUrl: null,
-  emailVerified: false,
-  bio: '',
-  agents: []
-});
+interface ProfileRow {
+  id: string;
+  name: string | null;
+  email: string;
+  role: UserRole | null;
+  is_active: boolean | null;
+  avatar_url: string | null;
+  email_verified: boolean | null;
+  bio: string | null;
+}
 
-const sanitizeAgent = (agent: AgentProfile): AgentProfile => ({
-  ...agent,
-  name: agent.name.trim(),
-  description: agent.description,
-  tools: agent.tools.map((tool) => tool.trim()).filter((tool) => tool.length > 0),
-  webhookUrl: agent.webhookUrl.trim()
+const mapProfile = (row: ProfileRow, agents: AgentProfile[] = []): AuthUser => ({
+  id: row.id,
+  name: row.name?.trim() || row.email,
+  email: row.email,
+  role: row.role ?? 'user',
+  isActive: row.is_active ?? true,
+  avatarUrl: row.avatar_url,
+  emailVerified: row.email_verified ?? false,
+  agents,
+  bio: row.bio ?? undefined
 });
-
-const sanitizeUsers = (users: StoredUser[]): AuthUser[] =>
-  users.map((user) => ({
-    ...toAuthUser(user),
-    agents: user.agents.map(sanitizeAgent)
-  }));
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [users, setUsers] = useState<StoredUser[]>(() => loadStoredUsers());
-  const [currentUserId, setCurrentUserId] = useState<string | null>(() => loadCurrentUserId());
+  const [currentUser, setCurrentUser] = useState<AuthUser | null>(null);
+  const [users, setUsers] = useState<AuthUser[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
-  const currentUser = useMemo(
-    () => users.find((user) => user.id === currentUserId) ?? null,
-    [users, currentUserId]
+  const fetchProfile = useCallback(
+    async (userId: string): Promise<AuthUser | null> => {
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('id', userId)
+        .single();
+
+      if (error) {
+        if (error.code === 'PGRST116') {
+          return null;
+        }
+        throw new Error(`Profil konnte nicht geladen werden: ${error.message}`);
+      }
+
+      return mapProfile(data as ProfileRow, []);
+    },
+    []
   );
 
-  const persistUsers = useCallback((nextUsers: StoredUser[]) => {
-    setUsers(nextUsers);
-    saveStoredUsers(nextUsers);
+  const fetchAllUsers = useCallback(async () => {
+    const { data, error } = await supabase.from('profiles').select('*');
+
+    if (error) {
+      throw new Error(`Nutzerliste konnte nicht geladen werden: ${error.message}`);
+    }
+
+    const profiles = (data as ProfileRow[]) ?? [];
+    return profiles.map((profile) => mapProfile(profile, []));
   }, []);
+
+  const refreshState = useCallback(
+    async (shouldLoadUsers = true) => {
+      setIsLoading(true);
+      try {
+        const {
+          data: { session }
+        } = await supabase.auth.getSession();
+
+        const authUser = session?.user ?? null;
+
+        if (!authUser) {
+          setCurrentUser(null);
+          setUsers([]);
+          return;
+        }
+
+        const profile = await fetchProfile(authUser.id);
+
+        if (!profile) {
+          const name =
+            typeof authUser.user_metadata?.name === 'string'
+              ? authUser.user_metadata.name
+              : authUser.email ?? 'Neuer Nutzer';
+
+          const { error } = await supabase.from('profiles').insert({
+            id: authUser.id,
+            email: authUser.email,
+            name,
+            role: 'user',
+            is_active: true,
+            avatar_url: null,
+            email_verified: Boolean(authUser.email_confirmed_at),
+            bio: null
+          });
+
+          if (error) {
+            throw new Error(`Profil konnte nicht erstellt werden: ${error.message}`);
+          }
+
+          const newProfile = await fetchProfile(authUser.id);
+          setCurrentUser(newProfile);
+          if (shouldLoadUsers && newProfile?.role === 'admin') {
+            setUsers(await fetchAllUsers());
+          } else {
+            setUsers([]);
+          }
+          return;
+        }
+
+        setCurrentUser(profile);
+
+        if (shouldLoadUsers && profile.role === 'admin') {
+          setUsers(await fetchAllUsers());
+        } else {
+          setUsers([]);
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [fetchAllUsers, fetchProfile]
+  );
+
+  useEffect(() => {
+    refreshState().catch((error) => {
+      console.error(error);
+    });
+
+    const {
+      data: { subscription }
+    } = supabase.auth.onAuthStateChange(() => {
+      refreshState().catch((error) => {
+        console.error(error);
+      });
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [refreshState]);
 
   const login = useCallback(
     async ({ email, password }: AuthCredentials) => {
-      const normalizedEmail = email.toLowerCase().trim();
-      const existingUser = users.find((user) => user.email === normalizedEmail);
+      const { error } = await supabase.auth.signInWithPassword({
+        email: email.toLowerCase().trim(),
+        password
+      });
 
-      if (!existingUser || existingUser.password !== password) {
-        throw new Error('E-Mail oder Passwort ist ungültig.');
+      if (error) {
+        throw new Error(error.message);
       }
 
-      if (!existingUser.isActive) {
+      const {
+        data: { user }
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        throw new Error('Anmeldung fehlgeschlagen.');
+      }
+
+      const profile = await fetchProfile(user.id);
+
+      if (profile && !profile.isActive) {
+        await supabase.auth.signOut();
+        setCurrentUser(null);
         throw new Error('Dein Zugang ist aktuell deaktiviert. Bitte kontaktiere das Admin-Team.');
       }
 
-      setCurrentUserId(existingUser.id);
-      saveCurrentUserId(existingUser.id);
+      await refreshState();
     },
-    [users]
+    [fetchProfile, refreshState]
   );
 
   const register = useCallback(
@@ -111,167 +216,171 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         throw new Error('Bitte gib einen Namen an.');
       }
 
-      const emailAlreadyExists = users.some((user) => user.email === normalizedEmail);
+      const { data, error } = await supabase.auth.signUp({
+        email: normalizedEmail,
+        password,
+        options: {
+          data: { name: trimmedName }
+        }
+      });
 
-      if (emailAlreadyExists) {
-        throw new Error('Für diese E-Mail existiert bereits ein Account.');
+      if (error) {
+        throw new Error(error.message);
       }
 
-      const newUser = createUserFromRegistration({
-        name: trimmedName,
-        email: normalizedEmail,
-        password
-      });
-      const nextUsers = [...users, newUser];
+      const user = data.user;
+      if (!user) {
+        throw new Error('Registrierung fehlgeschlagen.');
+      }
 
-      persistUsers(nextUsers);
-      setCurrentUserId(newUser.id);
-      saveCurrentUserId(newUser.id);
+      if (data.session) {
+        const { error: profileError } = await supabase.from('profiles').upsert({
+          id: user.id,
+          email: normalizedEmail,
+          name: trimmedName,
+          role: 'user',
+          is_active: true,
+          avatar_url: null,
+          email_verified: Boolean(user.email_confirmed_at),
+          bio: null
+        });
+
+        if (profileError && profileError.code !== '42501') {
+          throw new Error(`Profil konnte nicht gespeichert werden: ${profileError.message}`);
+        }
+
+        if (profileError?.code === '42501') {
+          console.info(
+            'Profile-Insert aufgrund von RLS verweigert. Profil wird beim nächsten Login automatisch angelegt.'
+          );
+        }
+      } else {
+        console.info(
+          'Keine aktive Session nach Registrierung – Profilanlage wird auf den ersten Login verschoben.'
+        );
+      }
+
+      await refreshState(false);
     },
-    [persistUsers, users]
+    [refreshState]
   );
 
-  const logout = useCallback(() => {
-    setCurrentUserId(null);
-    saveCurrentUserId(null);
+  const logout = useCallback(async () => {
+    const { error } = await supabase.auth.signOut();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    setCurrentUser(null);
+    setUsers([]);
   }, []);
 
   const updateProfile = useCallback(
-    (updates: ProfileUpdatePayload) => {
+    async (updates: ProfileUpdatePayload) => {
       if (!currentUser) {
+        throw new Error('Kein Nutzer angemeldet.');
+      }
+
+      const payload: Record<string, unknown> = {};
+
+      if (typeof updates.name === 'string') {
+        payload.name = updates.name.trim();
+      }
+
+      if (typeof updates.bio === 'string') {
+        payload.bio = updates.bio;
+      }
+
+      if ('avatarUrl' in updates) {
+        payload.avatar_url = updates.avatarUrl ?? null;
+      }
+
+      if ('emailVerified' in updates) {
+        payload.email_verified = updates.emailVerified ?? false;
+      }
+
+      if (Object.keys(payload).length === 0) {
         return;
       }
 
-      const nextUsers = users.map((user) =>
-        user.id === currentUser.id
-          ? {
-              ...user,
-              ...updates,
-              name: updates.name?.trim() ?? user.name
-            }
-          : user
-      );
+      const { error } = await supabase.from('profiles').update(payload).eq('id', currentUser.id);
 
-      persistUsers(nextUsers);
+      if (error) {
+        throw new Error(`Profil konnte nicht aktualisiert werden: ${error.message}`);
+      }
+
+      if (typeof updates.name === 'string' && updates.name.trim()) {
+        await supabase.auth.updateUser({ data: { name: updates.name.trim() } });
+      }
+
+      await refreshState();
     },
-    [currentUser, persistUsers, users]
+    [currentUser, refreshState]
   );
 
   const addAgent = useCallback(
-    (agent: AgentDraft) => {
+    async (agent: AgentDraft) => {
       if (!currentUser) {
-        return;
+        throw new Error('Kein Nutzer angemeldet.');
       }
 
-      const trimmedName = agent.name.trim();
-      if (!trimmedName) {
-        throw new Error('Bitte gib einen Agent-Namen an.');
-      }
-
-      const newAgent: AgentProfile = {
-        id:
-          typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-            ? crypto.randomUUID()
-            : `agent-${Math.random().toString(36).slice(2, 10)}`,
-        name: trimmedName,
-        description: agent.description.trim(),
-        avatarUrl: agent.avatarUrl ?? null,
-        tools: agent.tools.map((tool) => tool.trim()).filter((tool) => tool.length > 0),
-        webhookUrl: agent.webhookUrl.trim()
-      };
-
-      const nextUsers = users.map((user) =>
-        user.id === currentUser.id
-          ? {
-              ...user,
-              agents: [...user.agents, newAgent]
-            }
-          : user
-      );
-
-      persistUsers(nextUsers);
+      console.warn('Agent-Verwaltung ist deaktiviert, da keine agents-Tabelle konfiguriert ist.', agent);
+      throw new Error('Agent-Verwaltung ist in dieser Supabase-Konfiguration nicht verfügbar.');
     },
-    [currentUser, persistUsers, users]
+    [currentUser]
   );
 
   const updateAgent = useCallback(
-    (agentId: string, updates: AgentUpdatePayload) => {
+    async (agentId: string, updates: AgentUpdatePayload) => {
       if (!currentUser) {
-        return;
+        throw new Error('Kein Nutzer angemeldet.');
       }
 
-      const nextUsers = users.map((user) =>
-        user.id === currentUser.id
-          ? {
-              ...user,
-              agents: user.agents.map((agent) =>
-                agent.id === agentId
-                  ? {
-                      ...agent,
-                      ...updates,
-                      name: updates.name?.trim() ?? agent.name,
-                      description: updates.description ?? agent.description,
-                      avatarUrl: updates.avatarUrl ?? agent.avatarUrl,
-                      tools: updates.tools
-                        ? updates.tools.map((tool) => tool.trim()).filter((tool) => tool.length > 0)
-                        : agent.tools,
-                      webhookUrl: updates.webhookUrl?.trim() ?? agent.webhookUrl
-                    }
-                  : agent
-              )
-            }
-          : user
-      );
-
-      persistUsers(nextUsers);
+      console.warn('Agent-Verwaltung ist deaktiviert, Update-Anfrage ignoriert.', agentId, updates);
+      throw new Error('Agent-Verwaltung ist in dieser Supabase-Konfiguration nicht verfügbar.');
     },
-    [currentUser, persistUsers, users]
+    [currentUser]
   );
 
   const removeAgent = useCallback(
-    (agentId: string) => {
+    async (agentId: string) => {
       if (!currentUser) {
-        return;
+        throw new Error('Kein Nutzer angemeldet.');
       }
 
-      const nextUsers = users.map((user) =>
-        user.id === currentUser.id
-          ? {
-              ...user,
-              agents: user.agents.filter((agent) => agent.id !== agentId)
-            }
-          : user
-      );
-
-      persistUsers(nextUsers);
+      console.warn('Agent-Verwaltung ist deaktiviert, Lösch-Anfrage ignoriert.', agentId);
+      throw new Error('Agent-Verwaltung ist in dieser Supabase-Konfiguration nicht verfügbar.');
     },
-    [currentUser, persistUsers, users]
+    [currentUser]
   );
 
   const toggleUserActive = useCallback(
-    (userId: string, nextActive: boolean) => {
-      const nextUsers = users.map((user) =>
-        user.id === userId
-          ? {
-              ...user,
-              isActive: nextActive
-            }
-          : user
-      );
+    async (userId: string, nextActive: boolean) => {
+      const { error } = await supabase
+        .from('profiles')
+        .update({ is_active: nextActive })
+        .eq('id', userId);
 
-      persistUsers(nextUsers);
+      if (error) {
+        throw new Error(`Nutzerstatus konnte nicht geändert werden: ${error.message}`);
+      }
 
       if (currentUser && currentUser.id === userId && !nextActive) {
-        logout();
+        await logout();
+        return;
       }
+
+      await refreshState();
     },
-    [currentUser, logout, persistUsers, users]
+    [currentUser, logout, refreshState]
   );
 
   const value = useMemo<AuthContextValue>(
     () => ({
-      currentUser: currentUser ? toAuthUser(currentUser) : null,
-      users: sanitizeUsers(users),
+      currentUser,
+      users,
+      isLoading,
       login,
       register,
       logout,
@@ -284,13 +393,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [
       addAgent,
       currentUser,
+      isLoading,
       login,
       logout,
       register,
-      toggleUserActive,
       removeAgent,
       updateAgent,
       updateProfile,
+      toggleUserActive,
       users
     ]
   );

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -155,7 +155,7 @@ export function ProfilePage() {
     resetAgentWebhookTest();
   };
 
-  const handleDeleteAgent = (agentId: string) => {
+  const handleDeleteAgent = async (agentId: string) => {
     if (typeof window !== 'undefined') {
       const shouldDelete = window.confirm('Möchtest du diesen Agent wirklich löschen?');
       if (!shouldDelete) {
@@ -163,7 +163,12 @@ export function ProfilePage() {
       }
     }
 
-    removeAgent(agentId);
+    try {
+      await removeAgent(agentId);
+    } catch (error) {
+      console.error(error);
+      setAgentError('Agent konnte nicht gelöscht werden. Bitte versuche es erneut.');
+    }
   };
 
   const handleAgentAvatarUpload = async (file: File | null) => {
@@ -201,7 +206,7 @@ export function ProfilePage() {
 
     try {
       if (agentModal.mode === 'create') {
-        addAgent({
+        await addAgent({
           name: agentForm.name,
           description: agentForm.description,
           avatarUrl: agentForm.avatarUrl,
@@ -209,7 +214,7 @@ export function ProfilePage() {
           webhookUrl: agentForm.webhookUrl
         });
       } else {
-        updateAgent(agentModal.agent.id, {
+        await updateAgent(agentModal.agent.id, {
           name: agentForm.name,
           description: agentForm.description,
           avatarUrl: agentForm.avatarUrl,
@@ -234,7 +239,7 @@ export function ProfilePage() {
     setFeedback(null);
 
     try {
-      updateProfile({
+      await updateProfile({
         name,
         bio,
         avatarUrl: avatarPreview
@@ -449,9 +454,12 @@ export function ProfilePage() {
                 <h1 className="mt-2 text-3xl font-semibold">Dein persönlicher Bereich</h1>
               </div>
               <button
-                onClick={() => {
-                  logout();
-                  navigate('/login', { replace: true });
+                onClick={async () => {
+                  try {
+                    await logout();
+                  } finally {
+                    navigate('/login', { replace: true });
+                  }
                 }}
                 className="rounded-full border border-white/20 px-5 py-2 text-xs font-semibold text-white/70 transition hover:bg-white/10"
               >
@@ -672,7 +680,9 @@ export function ProfilePage() {
                             <td className="px-4 py-3 text-right">
                               <button
                                 type="button"
-                                onClick={() => toggleUserActive(user.id, !user.isActive)}
+                                onClick={() => {
+                                  void toggleUserActive(user.id, !user.isActive);
+                                }}
                                 className="rounded-full border border-white/10 px-4 py-2 text-xs font-semibold text-white/70 transition hover:bg-white/10 disabled:opacity-40"
                                 disabled={user.id === currentUser.id}
                               >

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('VITE_SUPABASE_URL ist nicht gesetzt.');
+}
+
+if (!supabaseKey) {
+  throw new Error('VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY ist nicht gesetzt.');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseKey);
+
+export default supabase;


### PR DESCRIPTION
## Summary
- remove any Supabase queries that targeted the non-existent `agents` table so authentication only depends on `public.profiles`
- make the agent CRUD actions short-circuit with clear messaging instead of hitting an `agents` table
- guard profile creation during signup so row-level security errors no longer break registration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d18c8f9bc88324b671784758f2346a