### PR TITLE
refactor: align supabase integration with utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.1.3",
+        "@supabase/supabase-js": "^2.74.0",
         "clsx": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1163,6 +1164,80 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.74.0.tgz",
+      "integrity": "sha512-EJYDxYhBCOS40VJvfQ5zSjo8Ku7JbTICLTcmXt4xHMQZt4IumpRfHg11exXI9uZ6G7fhsQlNgbzDhFN4Ni9NnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.74.0.tgz",
+      "integrity": "sha512-VqWYa981t7xtIFVf7LRb9meklHckbH/tqwaML5P3LgvlaZHpoSPjMCNLcquuLYiJLxnh2rio7IxLh+VlvRvSWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.74.0.tgz",
+      "integrity": "sha512-9Ypa2eS0Ib/YQClE+BhDSjx7OKjYEF6LAGjTB8X4HucdboGEwR0LZKctNfw6V0PPIAVjjzZxIlNBXGv0ypIkHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.74.0.tgz",
+      "integrity": "sha512-K5VqpA4/7RO1u1nyD5ICFKzWKu58bIDcPxHY0aFA7MyWkFd0pzi/XYXeoSsAifnD9p72gPIpgxVXCQZKJg1ktQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.74.0.tgz",
+      "integrity": "sha512-o0cTQdMqHh4ERDLtjUp1/KGPbQoNwKRxUh6f8+KQyjC5DSmiw/r+jgFe/WHh067aW+WU8nA9Ytw9ag7OhzxEkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.74.0.tgz",
+      "integrity": "sha512-IEMM/V6gKdP+N/X31KDIczVzghDpiPWFGLNjS8Rus71KvV6y6ueLrrE/JGCHDrU+9pq5copF3iCa0YQh+9Lq9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.74.0",
+        "@supabase/functions-js": "2.74.0",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "2.74.0",
+        "@supabase/realtime-js": "2.74.0",
+        "@supabase/storage-js": "2.74.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1260,13 +1335,16 @@
       "version": "24.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -1299,6 +1377,15 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -4235,6 +4322,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -4280,10 +4373,7 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
       "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -4498,6 +4588,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4610,6 +4716,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.3",
+    "@supabase/supabase-js": "^2.74.0",
     "clsx": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,69 @@
+import { useEffect, useState } from 'react';
 import { Route, Routes, Navigate } from 'react-router-dom';
+import { supabase } from './utils/supabase';
 import { ChatPage } from './pages/ChatPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { LoginPage } from './pages/LoginPage';
 import { RequireAuth } from './components/RequireAuth';
 import { ProfilePage } from './pages/ProfilePage';
 
+interface TodoRecord {
+  id?: string | number;
+  title?: string;
+  [key: string]: unknown;
+}
+
 function App() {
+  const [todos, setTodos] = useState<TodoRecord[]>([]);
+
+  useEffect(() => {
+    const getTodos = async () => {
+      const { data, error } = await supabase.from('todos').select('*');
+
+      if (error) {
+        console.error('Fehler beim Laden der Todos aus Supabase', error);
+        return;
+      }
+
+      if (data && data.length > 0) {
+        setTodos(data as TodoRecord[]);
+      }
+    };
+
+    void getTodos();
+  }, []);
+
   return (
-    <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route element={<RequireAuth />}>
-        <Route path="/" element={<ChatPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
-        <Route path="/profile" element={<ProfilePage />} />
-      </Route>
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+    <>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route element={<RequireAuth />}>
+          <Route path="/" element={<ChatPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/profile" element={<ProfilePage />} />
+        </Route>
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+      {todos.length > 0 && (
+        <div style={{ display: 'none' }} aria-hidden="true">
+          <ul>
+            {todos.map((todo, index) => (
+              <li
+                key={
+                  typeof todo.id !== 'undefined' && todo.id !== null
+                    ? String(todo.id)
+                    : `todo-${index}`
+                }
+              >
+                {typeof todo.title === 'string' && todo.title.length > 0
+                  ? todo.title
+                  : JSON.stringify(todo)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -18,6 +18,29 @@ import {
   RegistrationPayload,
   UserRole
 } from '../types/auth';
+import { supabase } from '../utils/supabase';
+
+type ProfileRow = {
+  id: string;
+  email: string | null;
+  display_name: string | null;
+  name: string | null;
+  avatar_url: string | null;
+  role: string | null;
+  bio: string | null;
+  email_verified: string | null;
+  is_active: boolean | null;
+};
+
+type AgentConversationRow = {
+  profile_id: string | null;
+  agent_id: string | null;
+  agent_name: string | null;
+  agent_description: string | null;
+  agent_avatar_url: string | null;
+  agent_webhook_url: string | null;
+  agent_tools: unknown;
+};
 
 interface AuthContextValue {
   currentUser: AuthUser | null;
@@ -33,210 +56,133 @@ interface AuthContextValue {
   removeAgent: (agentId: string) => Promise<void>;
 }
 
-const USERS_STORAGE_KEY = 'aiti-auth-users';
-const SESSION_STORAGE_KEY = 'aiti-auth-session';
-
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
-type StoredAgentProfile = AgentProfile;
-
-type StoredAuthUser = Omit<AuthUser, 'hasRemoteProfile'> & {
-  password: string;
-};
-
-const generateId = () => {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-
-  const randomSegment = () => Math.random().toString(16).slice(2, 10).padEnd(8, '0');
-  return `${randomSegment()}-${randomSegment().slice(0, 4)}-${randomSegment().slice(0, 4)}-${randomSegment().slice(0, 4)}-${randomSegment()}${randomSegment()}`.slice(0, 36);
-};
-
-const sanitizeTools = (tools: string[] | undefined): string[] => {
+const sanitizeTools = (tools: unknown): string[] => {
   if (!Array.isArray(tools)) {
     return [];
   }
 
-  const normalized = tools
-    .map((tool) => tool.trim())
-    .filter((tool) => tool.length > 0);
+  const sanitized = tools
+    .filter((tool): tool is string => typeof tool === 'string' && tool.trim().length > 0)
+    .map((tool) => tool.trim());
 
-  return Array.from(new Set(normalized));
+  return Array.from(new Set(sanitized));
 };
 
-const sanitizeAgent = (agent: AgentProfile): AgentProfile => ({
-  id: agent.id,
-  name: agent.name.trim().length > 0 ? agent.name.trim() : 'Unbenannter Agent',
-  description: agent.description?.trim() ?? '',
-  avatarUrl: agent.avatarUrl ?? null,
-  tools: sanitizeTools(agent.tools),
-  webhookUrl: agent.webhookUrl?.trim() ?? ''
+const sanitizeAgentDraft = (draft: AgentDraft) => ({
+  name: draft.name?.trim().length ? draft.name.trim() : 'Unbenannter Agent',
+  description: draft.description?.trim() ?? '',
+  avatarUrl: draft.avatarUrl ?? null,
+  tools: sanitizeTools(draft.tools),
+  webhookUrl: draft.webhookUrl?.trim() ?? ''
 });
 
-const sanitizeAgents = (agents: StoredAgentProfile[] | undefined): StoredAgentProfile[] => {
-  if (!agents) {
-    return [];
-  }
-
-  return agents
-    .filter((agent): agent is StoredAgentProfile => Boolean(agent) && typeof agent.id === 'string')
-    .map((agent) => sanitizeAgent(agent));
-};
-
-const toAuthUser = (stored: StoredAuthUser): AuthUser => ({
-  id: stored.id,
-  name: stored.name,
-  email: stored.email,
-  role: stored.role,
-  isActive: stored.isActive,
-  avatarUrl: stored.avatarUrl ?? null,
-  emailVerified: stored.emailVerified,
-  agents: sanitizeAgents(stored.agents),
-  bio: stored.bio,
-  hasRemoteProfile: true
-});
-
-const createDefaultUser = (): StoredAuthUser => ({
-  id: generateId(),
-  name: 'Demo Nutzer',
-  email: 'demo@aiti.local',
-  role: 'admin',
-  isActive: true,
-  avatarUrl: null,
-  emailVerified: true,
-  agents: [],
-  bio: '',
-  password: 'aiti-demo'
-});
-
-const readStoredUsers = (): StoredAuthUser[] => {
-  if (typeof window === 'undefined') {
-    return [createDefaultUser()];
-  }
-
-  const raw = window.localStorage.getItem(USERS_STORAGE_KEY);
-  if (!raw) {
-    const defaults = [createDefaultUser()];
-    window.localStorage.setItem(USERS_STORAGE_KEY, JSON.stringify(defaults));
-    return defaults;
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as Array<Partial<StoredAuthUser>>;
-    if (!Array.isArray(parsed) || parsed.length === 0) {
-      const defaults = [createDefaultUser()];
-      window.localStorage.setItem(USERS_STORAGE_KEY, JSON.stringify(defaults));
-      return defaults;
-    }
-
-    return parsed
-      .filter((candidate): candidate is Partial<StoredAuthUser> => Boolean(candidate) && typeof candidate === 'object')
-      .map((candidate) => {
-        const base: StoredAuthUser = {
-          id: typeof candidate.id === 'string' && candidate.id.trim().length > 0 ? candidate.id : generateId(),
-          name: typeof candidate.name === 'string' && candidate.name.trim().length > 0 ? candidate.name.trim() : 'Neuer Nutzer',
-          email:
-            typeof candidate.email === 'string' && candidate.email.trim().length > 0
-              ? candidate.email.trim().toLowerCase()
-              : 'demo@aiti.local',
-          role: candidate.role === 'admin' ? 'admin' : 'user',
-          isActive: typeof candidate.isActive === 'boolean' ? candidate.isActive : true,
-          avatarUrl: typeof candidate.avatarUrl === 'string' ? candidate.avatarUrl : null,
-          emailVerified: typeof candidate.emailVerified === 'boolean' ? candidate.emailVerified : false,
-          agents: sanitizeAgents(candidate.agents as StoredAgentProfile[]),
-          bio: typeof candidate.bio === 'string' ? candidate.bio : '',
-          password:
-            typeof candidate.password === 'string' && candidate.password.length > 0
-              ? candidate.password
-              : 'aiti-demo'
-        };
-
-        return base;
-      });
-  } catch (error) {
-    console.error('Konnte gespeicherte Nutzer nicht lesen.', error);
-    const defaults = [createDefaultUser()];
-    window.localStorage.setItem(USERS_STORAGE_KEY, JSON.stringify(defaults));
-    return defaults;
-  }
-};
-
-const persistStoredUsers = (users: StoredAuthUser[]) => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  window.localStorage.setItem(USERS_STORAGE_KEY, JSON.stringify(users));
-};
-
-const readActiveSession = (): string | null => {
-  if (typeof window === 'undefined') {
+const mapConversationRowToAgent = (row: AgentConversationRow): AgentProfile | null => {
+  if (!row.agent_id) {
     return null;
   }
 
-  const stored = window.localStorage.getItem(SESSION_STORAGE_KEY);
-  return stored && stored.trim().length > 0 ? stored : null;
+  return {
+    id: row.agent_id,
+    name: row.agent_name?.trim().length ? row.agent_name.trim() : 'Unbenannter Agent',
+    description: row.agent_description?.trim() ?? '',
+    avatarUrl: row.agent_avatar_url ?? null,
+    tools: sanitizeTools(row.agent_tools),
+    webhookUrl: row.agent_webhook_url?.trim() ?? ''
+  };
 };
 
-const persistActiveSession = (sessionId: string | null) => {
-  if (typeof window === 'undefined') {
-    return;
-  }
+const resolveUserRole = (value: string | null | undefined): UserRole => (value === 'admin' ? 'admin' : 'user');
 
-  if (sessionId) {
-    window.localStorage.setItem(SESSION_STORAGE_KEY, sessionId);
-  } else {
-    window.localStorage.removeItem(SESSION_STORAGE_KEY);
-  }
+const toBoolean = (value: string | null | undefined) => value?.toLowerCase() === 'true';
+
+const mapProfileRowToAuthUser = (row: ProfileRow, agents: AgentProfile[]): AuthUser => {
+  const nameCandidate = [row.display_name, row.name, row.email]
+    .find((candidate) => typeof candidate === 'string' && candidate.trim().length > 0)
+    ?.trim();
+
+  const normalizedEmail = typeof row.email === 'string' && row.email.length > 0 ? row.email : '';
+
+  return {
+    id: row.id,
+    name: nameCandidate ?? 'AITI Nutzer',
+    email: normalizedEmail,
+    role: resolveUserRole(row.role),
+    isActive: typeof row.is_active === 'boolean' ? row.is_active : true,
+    avatarUrl: row.avatar_url ?? null,
+    emailVerified: toBoolean(row.email_verified),
+    agents,
+    bio: row.bio ?? '',
+    hasRemoteProfile: true
+  };
 };
 
-const ensureUniqueEmail = (users: StoredAuthUser[], email: string, excludeUserId?: string) => {
-  const normalizedEmail = email.trim().toLowerCase();
-  const conflict = users.some((user) => user.email === normalizedEmail && user.id !== excludeUserId);
-  if (conflict) {
-    throw new Error('Diese E-Mail-Adresse wird bereits verwendet.');
-  }
-};
+const createUuid = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Math.random().toString(16).slice(2, 10)}-${Math.random().toString(16).slice(2, 6)}-${Math.random()
+        .toString(16)
+        .slice(2, 6)}-${Math.random().toString(16).slice(2, 6)}-${Math.random().toString(16).slice(2, 14)}`;
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [currentUser, setCurrentUser] = useState<AuthUser | null>(null);
   const [users, setUsers] = useState<AuthUser[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [sessionUserId, setSessionUserId] = useState<string | null>(null);
-  const storedUsersRef = useRef<StoredAuthUser[]>([]);
+  const isMountedRef = useRef(true);
 
   useEffect(() => {
-    const storedUsers = readStoredUsers();
-    storedUsersRef.current = storedUsers;
-    const mappedUsers = storedUsers.map(toAuthUser);
-    setUsers(mappedUsers);
-
-    const activeSession = readActiveSession();
-    setSessionUserId(activeSession);
-
-    if (activeSession) {
-      const matching = storedUsers.find((user) => user.id === activeSession);
-      if (matching && matching.isActive) {
-        setCurrentUser(toAuthUser(matching));
-      }
-    }
-
-    setIsLoading(false);
+    return () => {
+      isMountedRef.current = false;
+    };
   }, []);
 
-  const updateStateFromUsers = useCallback(
-    (nextUsers: StoredAuthUser[], nextSessionId: string | null) => {
-      storedUsersRef.current = nextUsers;
-      persistStoredUsers(nextUsers);
-      setUsers(nextUsers.map(toAuthUser));
+  const fetchAndSetUsers = useCallback(
+    async (activeUserId?: string | null) => {
+      const targetUserId = activeUserId ?? sessionUserId ?? null;
 
-      if (nextSessionId) {
-        const activeUser = nextUsers.find((user) => user.id === nextSessionId);
-        setCurrentUser(activeUser ? toAuthUser(activeUser) : null);
-      } else if (sessionUserId) {
-        const activeUser = nextUsers.find((user) => user.id === sessionUserId);
-        setCurrentUser(activeUser ? toAuthUser(activeUser) : null);
+      const { data: profileRows, error: profilesError } = await supabase.from('profiles').select('*');
+      if (profilesError) {
+        throw new Error(profilesError.message ?? 'Profile konnten nicht geladen werden.');
+      }
+
+      const { data: conversationRows, error: conversationsError } = await supabase
+        .from('agent_conversations')
+        .select(
+          'profile_id, agent_id, agent_name, agent_description, agent_avatar_url, agent_webhook_url, agent_tools'
+        );
+      if (conversationsError) {
+        throw new Error(conversationsError.message ?? 'Agenten konnten nicht geladen werden.');
+      }
+
+      const groupedAgents = new Map<string, AgentProfile[]>();
+      for (const row of conversationRows ?? []) {
+        if (!row?.profile_id) {
+          continue;
+        }
+
+        const agent = mapConversationRowToAgent(row);
+        if (!agent) {
+          continue;
+        }
+
+        const existing = groupedAgents.get(row.profile_id) ?? [];
+        existing.push(agent);
+        groupedAgents.set(row.profile_id, existing);
+      }
+
+      const mappedUsers = (profileRows ?? []).map((row) => mapProfileRowToAuthUser(row, groupedAgents.get(row.id) ?? []));
+
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      setUsers(mappedUsers);
+
+      if (targetUserId) {
+        const active = mappedUsers.find((user) => user.id === targetUserId) ?? null;
+        setCurrentUser(active);
       } else {
         setCurrentUser(null);
       }
@@ -244,57 +190,127 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [sessionUserId]
   );
 
-  const login = useCallback(async ({ email, password }: AuthCredentials) => {
-    const normalizedEmail = email.trim().toLowerCase();
-    const storedUsers = storedUsersRef.current;
-    const matching = storedUsers.find((user) => user.email === normalizedEmail);
+  useEffect(() => {
+    let isSubscribed = true;
 
-    if (!matching || matching.password !== password) {
-      throw new Error('Ungültige Anmeldedaten.');
-    }
+    const initialize = async () => {
+      setIsLoading(true);
+      try {
+        const { data: sessionResponse, error: sessionError } = await supabase.auth.getSession();
+        if (sessionError) {
+          throw sessionError;
+        }
 
-    if (!matching.isActive) {
-      throw new Error('Dieser Account ist deaktiviert. Bitte wende dich an eine Administratorin.');
-    }
+        if (!isSubscribed) {
+          return;
+        }
 
-    persistActiveSession(matching.id);
-    setSessionUserId(matching.id);
-    setCurrentUser(toAuthUser(matching));
-  }, []);
+        const activeUserId = sessionResponse.session?.user?.id ?? null;
+        setSessionUserId(activeUserId);
+        await fetchAndSetUsers(activeUserId);
+      } catch (error) {
+        console.error('Konnte Auth-Daten nicht laden.', error);
+        if (isMountedRef.current) {
+          setUsers([]);
+          setCurrentUser(null);
+        }
+      } finally {
+        if (isMountedRef.current) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void initialize();
+
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      const nextUserId = session?.user?.id ?? null;
+      setSessionUserId(nextUserId);
+      void fetchAndSetUsers(nextUserId);
+    });
+
+    return () => {
+      isSubscribed = false;
+      subscription?.subscription.unsubscribe();
+    };
+  }, [fetchAndSetUsers]);
+
+  const login = useCallback(
+    async ({ email, password }: AuthCredentials) => {
+      const normalizedEmail = email.trim().toLowerCase();
+      const { data, error } = await supabase.auth.signInWithPassword({ email: normalizedEmail, password });
+      if (error) {
+        throw new Error(error.message ?? 'Anmeldung fehlgeschlagen.');
+      }
+
+      const userId = data.user?.id ?? null;
+      setSessionUserId(userId);
+      await fetchAndSetUsers(userId);
+    },
+    [fetchAndSetUsers]
+  );
 
   const register = useCallback(
     async ({ name, email, password }: RegistrationPayload) => {
-      const storedUsers = storedUsersRef.current;
-      ensureUniqueEmail(storedUsers, email);
+      const normalizedEmail = email.trim().toLowerCase();
+      const trimmedName = name.trim();
 
-      const newUser: StoredAuthUser = {
-        id: generateId(),
-        name: name.trim().length > 0 ? name.trim() : 'Neuer Nutzer',
-        email: email.trim().toLowerCase(),
-        role: 'user',
-        isActive: true,
-        avatarUrl: null,
-        emailVerified: false,
-        agents: [],
-        bio: '',
-        password
-      };
+      const { data, error } = await supabase.auth.signUp({
+        email: normalizedEmail,
+        password,
+        options: {
+          data: {
+            display_name: trimmedName,
+            name: trimmedName
+          }
+        }
+      });
 
-      const nextUsers = [...storedUsers, newUser];
-      persistActiveSession(newUser.id);
-      setSessionUserId(newUser.id);
-      updateStateFromUsers(nextUsers, newUser.id);
+      if (error) {
+        throw new Error(error.message ?? 'Registrierung fehlgeschlagen.');
+      }
 
-      return { sessionExists: false };
+      const supabaseUser = data.user;
+      if (supabaseUser) {
+        const { error: profileError } = await supabase.from('profiles').upsert({
+          id: supabaseUser.id,
+          email: supabaseUser.email ?? normalizedEmail,
+          display_name: trimmedName || supabaseUser.email || 'Neuer Nutzer',
+          name: trimmedName || null,
+          avatar_url: null,
+          role: 'user',
+          bio: '',
+          email_verified: supabaseUser.email_confirmed_at ? 'true' : 'false',
+          is_active: true
+        });
+
+        if (profileError) {
+          throw new Error(profileError.message ?? 'Profil konnte nicht gespeichert werden.');
+        }
+
+        await fetchAndSetUsers(supabaseUser.id);
+      } else {
+        await fetchAndSetUsers(null);
+      }
+
+      return { sessionExists: Boolean(data.session) };
     },
-    [updateStateFromUsers]
+    [fetchAndSetUsers]
   );
 
   const logout = useCallback(async () => {
-    persistActiveSession(null);
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      throw new Error(error.message ?? 'Abmeldung fehlgeschlagen.');
+    }
+
     setSessionUserId(null);
-    setCurrentUser(null);
-  }, []);
+    await fetchAndSetUsers(null);
+  }, [fetchAndSetUsers]);
 
   const updateProfile = useCallback(
     async (updates: ProfileUpdatePayload) => {
@@ -302,58 +318,57 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         throw new Error('Kein aktiver Nutzer gefunden.');
       }
 
-      const storedUsers = storedUsersRef.current;
-      const index = storedUsers.findIndex((user) => user.id === currentUser.id);
-      if (index === -1) {
-        throw new Error('Nutzer konnte nicht aktualisiert werden.');
-      }
-
-      const updatedUser: StoredAuthUser = {
-        ...storedUsers[index],
-        name: updates.name?.trim()?.length ? updates.name.trim() : storedUsers[index].name,
-        avatarUrl: updates.avatarUrl ?? storedUsers[index].avatarUrl,
-        bio:
-          typeof updates.bio === 'string'
-            ? updates.bio
-            : typeof storedUsers[index].bio === 'string'
-            ? storedUsers[index].bio
-            : '',
-        emailVerified:
-          typeof updates.emailVerified === 'boolean' ? updates.emailVerified : storedUsers[index].emailVerified
+      const trimmedName = updates.name?.trim();
+      const preparedUpdates: Record<string, unknown> = {
+        updated_at: new Date().toISOString()
       };
 
-      const nextUsers = [...storedUsers];
-      nextUsers[index] = updatedUser;
-      updateStateFromUsers(nextUsers, currentUser.id);
+      if (typeof trimmedName === 'string' && trimmedName.length > 0) {
+        preparedUpdates.display_name = trimmedName;
+        preparedUpdates.name = trimmedName;
+      }
+
+      if (updates.avatarUrl !== undefined) {
+        preparedUpdates.avatar_url = updates.avatarUrl;
+      }
+
+      if (typeof updates.bio === 'string') {
+        preparedUpdates.bio = updates.bio;
+      }
+
+      if (typeof updates.emailVerified === 'boolean') {
+        preparedUpdates.email_verified = updates.emailVerified ? 'true' : 'false';
+      }
+
+      const { error } = await supabase.from('profiles').update(preparedUpdates).eq('id', currentUser.id);
+      if (error) {
+        throw new Error(error.message ?? 'Profil konnte nicht aktualisiert werden.');
+      }
+
+      await fetchAndSetUsers(currentUser.id);
     },
-    [currentUser, updateStateFromUsers]
+    [currentUser, fetchAndSetUsers]
   );
 
   const toggleUserActive = useCallback(
     async (userId: string, nextActive: boolean) => {
-      const storedUsers = storedUsersRef.current;
-      const index = storedUsers.findIndex((user) => user.id === userId);
-      if (index === -1) {
-        throw new Error('Nutzer wurde nicht gefunden.');
+      const { error } = await supabase
+        .from('profiles')
+        .update({ is_active: nextActive, updated_at: new Date().toISOString() })
+        .eq('id', userId);
+
+      if (error) {
+        throw new Error(error.message ?? 'Nutzerstatus konnte nicht geändert werden.');
       }
 
-      const updatedUser: StoredAuthUser = {
-        ...storedUsers[index],
-        isActive: nextActive
-      };
-
-      const nextUsers = [...storedUsers];
-      nextUsers[index] = updatedUser;
-
-      const nextSessionId = nextActive ? sessionUserId : sessionUserId === userId ? null : sessionUserId;
-      if (sessionUserId === userId && !nextActive) {
-        persistActiveSession(null);
-        setSessionUserId(null);
+      if (currentUser?.id === userId && !nextActive) {
+        await logout();
+        return;
       }
 
-      updateStateFromUsers(nextUsers, nextSessionId);
+      await fetchAndSetUsers(currentUser?.id ?? sessionUserId ?? null);
     },
-    [sessionUserId, updateStateFromUsers]
+    [currentUser?.id, fetchAndSetUsers, logout, sessionUserId]
   );
 
   const addAgent = useCallback(
@@ -362,27 +377,34 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         throw new Error('Kein aktiver Nutzer gefunden.');
       }
 
-      const storedUsers = storedUsersRef.current;
-      const index = storedUsers.findIndex((user) => user.id === currentUser.id);
-      if (index === -1) {
-        throw new Error('Nutzer konnte nicht aktualisiert werden.');
-      }
+      const sanitized = sanitizeAgentDraft(agent);
+      const timestamp = new Date().toISOString();
+      const agentId = createUuid();
 
-      const newAgent: StoredAgentProfile = sanitizeAgent({
-        id: generateId(),
-        ...agent
+      const { error } = await supabase.from('agent_conversations').insert({
+        id: createUuid(),
+        profile_id: currentUser.id,
+        agent_id: agentId,
+        agent_name: sanitized.name,
+        agent_description: sanitized.description,
+        agent_avatar_url: sanitized.avatarUrl,
+        agent_tools: sanitized.tools,
+        agent_webhook_url: sanitized.webhookUrl,
+        messages: [],
+        summary: null,
+        last_message_at: null,
+        title: sanitized.name,
+        created_at: timestamp,
+        updated_at: timestamp
       });
 
-      const updatedUser: StoredAuthUser = {
-        ...storedUsers[index],
-        agents: [...sanitizeAgents(storedUsers[index].agents), newAgent]
-      };
+      if (error) {
+        throw new Error(error.message ?? 'Agent konnte nicht erstellt werden.');
+      }
 
-      const nextUsers = [...storedUsers];
-      nextUsers[index] = updatedUser;
-      updateStateFromUsers(nextUsers, currentUser.id);
+      await fetchAndSetUsers(currentUser.id);
     },
-    [currentUser, updateStateFromUsers]
+    [currentUser, fetchAndSetUsers]
   );
 
   const updateAgent = useCallback(
@@ -391,35 +413,35 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         throw new Error('Kein aktiver Nutzer gefunden.');
       }
 
-      const storedUsers = storedUsersRef.current;
-      const index = storedUsers.findIndex((user) => user.id === currentUser.id);
-      if (index === -1) {
-        throw new Error('Nutzer konnte nicht aktualisiert werden.');
-      }
-
-      const agents = sanitizeAgents(storedUsers[index].agents);
-      const agentIndex = agents.findIndex((agent) => agent.id === agentId);
-      if (agentIndex === -1) {
-        throw new Error('Agent wurde nicht gefunden.');
-      }
-
-      const updatedAgent: StoredAgentProfile = sanitizeAgent({
-        ...agents[agentIndex],
-        ...updates
+      const sanitized = sanitizeAgentDraft({
+        name: updates.name ?? '',
+        description: updates.description ?? '',
+        avatarUrl: updates.avatarUrl ?? null,
+        tools: updates.tools ?? [],
+        webhookUrl: updates.webhookUrl ?? ''
       });
 
-      const nextAgents = [...agents];
-      nextAgents[agentIndex] = updatedAgent;
+      const { error } = await supabase
+        .from('agent_conversations')
+        .update({
+          agent_name: sanitized.name,
+          agent_description: sanitized.description,
+          agent_avatar_url: sanitized.avatarUrl,
+          agent_tools: sanitized.tools,
+          agent_webhook_url: sanitized.webhookUrl,
+          title: sanitized.name,
+          updated_at: new Date().toISOString()
+        })
+        .eq('profile_id', currentUser.id)
+        .eq('agent_id', agentId);
 
-      const nextUsers = [...storedUsers];
-      nextUsers[index] = {
-        ...storedUsers[index],
-        agents: nextAgents
-      };
+      if (error) {
+        throw new Error(error.message ?? 'Agent konnte nicht aktualisiert werden.');
+      }
 
-      updateStateFromUsers(nextUsers, currentUser.id);
+      await fetchAndSetUsers(currentUser.id);
     },
-    [currentUser, updateStateFromUsers]
+    [currentUser, fetchAndSetUsers]
   );
 
   const removeAgent = useCallback(
@@ -428,24 +450,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         throw new Error('Kein aktiver Nutzer gefunden.');
       }
 
-      const storedUsers = storedUsersRef.current;
-      const index = storedUsers.findIndex((user) => user.id === currentUser.id);
-      if (index === -1) {
-        throw new Error('Nutzer konnte nicht aktualisiert werden.');
+      const { error } = await supabase
+        .from('agent_conversations')
+        .delete()
+        .eq('profile_id', currentUser.id)
+        .eq('agent_id', agentId);
+
+      if (error) {
+        throw new Error(error.message ?? 'Agent konnte nicht entfernt werden.');
       }
 
-      const agents = sanitizeAgents(storedUsers[index].agents);
-      const nextAgents = agents.filter((agent) => agent.id !== agentId);
-
-      const nextUsers = [...storedUsers];
-      nextUsers[index] = {
-        ...storedUsers[index],
-        agents: nextAgents
-      };
-
-      updateStateFromUsers(nextUsers, currentUser.id);
+      await fetchAndSetUsers(currentUser.id);
     },
-    [currentUser, updateStateFromUsers]
+    [currentUser, fetchAndSetUsers]
   );
 
   const value = useMemo<AuthContextValue>(

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1,18 +1,21 @@
+import { supabase } from '../utils/supabase';
 import { Chat, ChatMessage } from '../data/sampleChats';
 
 export interface AgentConversationRecord {
   id: string;
   profile_id: string;
   agent_id: string;
-  agent_name: string | null;
-  agent_description: string | null;
-  agent_avatar_url: string | null;
-  agent_webhook_url: string | null;
-  messages: ChatMessage[];
+  title: string | null;
   summary: string | null;
+  messages: ChatMessage[];
   last_message_at: string | null;
   created_at: string | null;
   updated_at: string | null;
+  agent_name: string | null;
+  agent_description: string | null;
+  agent_avatar_url: string | null;
+  agent_tools: string[];
+  agent_webhook_url: string | null;
 }
 
 export interface AgentConversationUpdatePayload {
@@ -23,22 +26,44 @@ export interface AgentConversationUpdatePayload {
   agentDescription?: string | null;
   agentAvatarUrl?: string | null;
   agentWebhookUrl?: string | null;
+  agentTools?: string[];
 }
 
-const CONVERSATION_PREFIX = 'aiti-agent-conversations:';
-
-const generateId = () => {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-
-  const segments = Array.from({ length: 5 }, () => Math.random().toString(16).slice(2, 10));
-  return `${segments[0]}-${segments[1].slice(0, 4)}-${segments[2].slice(0, 4)}-${segments[3].slice(0, 4)}-${segments[4]}${Math.random()
-    .toString(16)
-    .slice(2, 10)}`.slice(0, 36);
+type AgentConversationRow = {
+  id: string;
+  profile_id: string;
+  agent_id: string;
+  title: string | null;
+  summary: string | null;
+  messages: unknown;
+  last_message_at: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  agent_name: string | null;
+  agent_description: string | null;
+  agent_avatar_url: string | null;
+  agent_tools: unknown;
+  agent_webhook_url: string | null;
 };
 
-const storageKey = (profileId: string) => `${CONVERSATION_PREFIX}${profileId}`;
+const createUuid = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Math.random().toString(16).slice(2, 10)}-${Math.random().toString(16).slice(2, 6)}-${Math.random()
+        .toString(16)
+        .slice(2, 6)}-${Math.random().toString(16).slice(2, 6)}-${Math.random().toString(16).slice(2, 14)}`;
+
+const sanitizeTools = (tools: unknown): string[] => {
+  if (!Array.isArray(tools)) {
+    return [];
+  }
+
+  const sanitized = tools
+    .filter((tool): tool is string => typeof tool === 'string' && tool.trim().length > 0)
+    .map((tool) => tool.trim());
+
+  return Array.from(new Set(sanitized));
+};
 
 const sanitizeMessages = (messages: unknown): ChatMessage[] => {
   if (!Array.isArray(messages)) {
@@ -80,61 +105,38 @@ const sanitizeMessages = (messages: unknown): ChatMessage[] => {
   return sanitized;
 };
 
-const sanitizeRecord = (profileId: string, record: Partial<AgentConversationRecord>): AgentConversationRecord => {
-  const baseId = typeof record.id === 'string' && record.id.length > 0 ? record.id : generateId();
-  const agentId = typeof record.agent_id === 'string' && record.agent_id.length > 0 ? record.agent_id : baseId;
-
-  return {
-    id: baseId,
-    profile_id: profileId,
-    agent_id: agentId,
-    agent_name: typeof record.agent_name === 'string' ? record.agent_name : null,
-    agent_description: typeof record.agent_description === 'string' ? record.agent_description : null,
-    agent_avatar_url: typeof record.agent_avatar_url === 'string' ? record.agent_avatar_url : null,
-    agent_webhook_url: typeof record.agent_webhook_url === 'string' ? record.agent_webhook_url : null,
-    messages: sanitizeMessages(record.messages),
-    summary: typeof record.summary === 'string' ? record.summary : null,
-    last_message_at: typeof record.last_message_at === 'string' ? record.last_message_at : null,
-    created_at: typeof record.created_at === 'string' ? record.created_at : null,
-    updated_at: typeof record.updated_at === 'string' ? record.updated_at : null
-  };
-};
-
-const readRecords = (profileId: string): AgentConversationRecord[] => {
-  if (typeof window === 'undefined') {
-    return [];
-  }
-
-  const raw = window.localStorage.getItem(storageKey(profileId));
-  if (!raw) {
-    return [];
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as Array<Partial<AgentConversationRecord>>;
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-
-    return parsed.map((record) => sanitizeRecord(profileId, record));
-  } catch (error) {
-    console.error('Konversationen konnten nicht gelesen werden.', error);
-    return [];
-  }
-};
-
-const writeRecords = (profileId: string, records: AgentConversationRecord[]) => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  window.localStorage.setItem(storageKey(profileId), JSON.stringify(records));
-};
+const sanitizeRecord = (row: AgentConversationRow): AgentConversationRecord => ({
+  id: row.id,
+  profile_id: row.profile_id,
+  agent_id: row.agent_id,
+  title: row.title,
+  summary: typeof row.summary === 'string' ? row.summary : null,
+  messages: sanitizeMessages(row.messages),
+  last_message_at: row.last_message_at,
+  created_at: row.created_at,
+  updated_at: row.updated_at,
+  agent_name: typeof row.agent_name === 'string' ? row.agent_name : null,
+  agent_description: typeof row.agent_description === 'string' ? row.agent_description : null,
+  agent_avatar_url: typeof row.agent_avatar_url === 'string' ? row.agent_avatar_url : null,
+  agent_tools: sanitizeTools(row.agent_tools),
+  agent_webhook_url: typeof row.agent_webhook_url === 'string' ? row.agent_webhook_url : null
+});
 
 export const fetchAgentConversations = async (
   profileId: string
 ): Promise<AgentConversationRecord[]> => {
-  return readRecords(profileId);
+  const { data, error } = await supabase
+    .from('agent_conversations')
+    .select('*')
+    .eq('profile_id', profileId)
+    .order('updated_at', { ascending: false, nullsFirst: false })
+    .order('created_at', { ascending: false, nullsFirst: false });
+
+  if (error) {
+    throw new Error(error.message ?? 'Konversationen konnten nicht geladen werden.');
+  }
+
+  return (data ?? []).map((row) => sanitizeRecord(row));
 };
 
 export const upsertAgentConversation = async (
@@ -142,58 +144,116 @@ export const upsertAgentConversation = async (
   agentId: string,
   updates: AgentConversationUpdatePayload
 ): Promise<AgentConversationRecord> => {
-  const records = readRecords(profileId);
-  const index = records.findIndex((record) => record.agent_id === agentId);
   const timestamp = new Date().toISOString();
+  const sanitizedMessages = updates.messages ? sanitizeMessages(updates.messages) : undefined;
+  const sanitizedTools = updates.agentTools ? sanitizeTools(updates.agentTools) : undefined;
 
-  if (index === -1) {
-    const record: AgentConversationRecord = {
-      id: generateId(),
+  const { data: existing, error: existingError, status } = await supabase
+    .from('agent_conversations')
+    .select('*')
+    .eq('profile_id', profileId)
+    .eq('agent_id', agentId)
+    .maybeSingle();
+
+  if (existingError && status !== 406) {
+    throw new Error(existingError.message ?? 'Konversation konnte nicht geladen werden.');
+  }
+
+  if (!existing) {
+    const insertPayload = {
+      id: createUuid(),
       profile_id: profileId,
       agent_id: agentId,
       agent_name: updates.agentName ?? null,
       agent_description: updates.agentDescription ?? null,
       agent_avatar_url: updates.agentAvatarUrl ?? null,
       agent_webhook_url: updates.agentWebhookUrl ?? null,
-      messages: updates.messages ?? [],
+      agent_tools: sanitizedTools ?? [],
+      messages: sanitizedMessages ?? [],
       summary: updates.summary ?? null,
       last_message_at: updates.lastMessageAt ?? null,
+      title: updates.agentName ?? null,
       created_at: timestamp,
       updated_at: timestamp
     };
 
-    const nextRecords = [...records, record];
-    writeRecords(profileId, nextRecords);
-    return record;
+    const { data, error } = await supabase
+      .from('agent_conversations')
+      .insert(insertPayload)
+      .select('*')
+      .single();
+
+    if (error) {
+      throw new Error(error.message ?? 'Konversation konnte nicht angelegt werden.');
+    }
+
+    return sanitizeRecord(data);
   }
 
-  const current = records[index];
-  const nextRecord: AgentConversationRecord = {
-    ...current,
-    messages: updates.messages ?? current.messages,
-    summary: updates.summary ?? current.summary,
-    last_message_at: updates.lastMessageAt ?? current.last_message_at,
-    agent_name: updates.agentName ?? current.agent_name,
-    agent_description: updates.agentDescription ?? current.agent_description,
-    agent_avatar_url: updates.agentAvatarUrl ?? current.agent_avatar_url,
-    agent_webhook_url: updates.agentWebhookUrl ?? current.agent_webhook_url,
+  const updatePayload: Record<string, unknown> = {
     updated_at: timestamp
   };
 
-  const nextRecords = [...records];
-  nextRecords[index] = nextRecord;
-  writeRecords(profileId, nextRecords);
+  if (sanitizedMessages) {
+    updatePayload.messages = sanitizedMessages;
+  }
 
-  return nextRecord;
+  if (updates.summary !== undefined) {
+    updatePayload.summary = updates.summary;
+  }
+
+  if (updates.lastMessageAt !== undefined) {
+    updatePayload.last_message_at = updates.lastMessageAt;
+  }
+
+  if (updates.agentName !== undefined) {
+    updatePayload.agent_name = updates.agentName;
+    updatePayload.title = updates.agentName;
+  }
+
+  if (updates.agentDescription !== undefined) {
+    updatePayload.agent_description = updates.agentDescription;
+  }
+
+  if (updates.agentAvatarUrl !== undefined) {
+    updatePayload.agent_avatar_url = updates.agentAvatarUrl;
+  }
+
+  if (updates.agentWebhookUrl !== undefined) {
+    updatePayload.agent_webhook_url = updates.agentWebhookUrl;
+  }
+
+  if (sanitizedTools) {
+    updatePayload.agent_tools = sanitizedTools;
+  }
+
+  const { data, error } = await supabase
+    .from('agent_conversations')
+    .update(updatePayload)
+    .eq('id', existing.id)
+    .select('*')
+    .single();
+
+  if (error) {
+    throw new Error(error.message ?? 'Konversation konnte nicht aktualisiert werden.');
+  }
+
+  return sanitizeRecord(data);
 };
 
 export const deleteAgentConversation = async (
   profileId: string,
   agentId: string
 ): Promise<void> => {
-  const records = readRecords(profileId);
-  const nextRecords = records.filter((record) => record.agent_id !== agentId);
-  writeRecords(profileId, nextRecords);
+  const { error } = await supabase
+    .from('agent_conversations')
+    .delete()
+    .eq('profile_id', profileId)
+    .eq('agent_id', agentId);
+
+  if (error) {
+    throw new Error(error.message ?? 'Konversation konnte nicht gelöscht werden.');
+  }
 };
 
 const formatDisplayTime = (value: string | null | undefined) => {

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,0 +1,19 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error(
+    'Supabase ist nicht konfiguriert. Bitte VITE_SUPABASE_URL und VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY setzen.'
+  );
+}
+
+export const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: {
+    persistSession: true,
+    storageKey: 'aiti-supabase-auth'
+  }
+});
+
+export default supabase;


### PR DESCRIPTION
## Summary
- add a shared Supabase client in `src/utils/supabase.ts` that reads the publishable key env var
- update the App bootstrap to run the Supabase todo fetch sample while retaining the existing routes
- point the auth context and chat service to the new Supabase utility and drop the old client wrapper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e66e5c698083248638a3dc68cc98bf