### PR TITLE
Integrate Supabase authentication and chat storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.1.3",
+        "@supabase/supabase-js": "^2.74.0",
         "clsx": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1163,6 +1164,80 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.74.0.tgz",
+      "integrity": "sha512-EJYDxYhBCOS40VJvfQ5zSjo8Ku7JbTICLTcmXt4xHMQZt4IumpRfHg11exXI9uZ6G7fhsQlNgbzDhFN4Ni9NnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.74.0.tgz",
+      "integrity": "sha512-VqWYa981t7xtIFVf7LRb9meklHckbH/tqwaML5P3LgvlaZHpoSPjMCNLcquuLYiJLxnh2rio7IxLh+VlvRvSWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.74.0.tgz",
+      "integrity": "sha512-9Ypa2eS0Ib/YQClE+BhDSjx7OKjYEF6LAGjTB8X4HucdboGEwR0LZKctNfw6V0PPIAVjjzZxIlNBXGv0ypIkHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.74.0.tgz",
+      "integrity": "sha512-K5VqpA4/7RO1u1nyD5ICFKzWKu58bIDcPxHY0aFA7MyWkFd0pzi/XYXeoSsAifnD9p72gPIpgxVXCQZKJg1ktQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.74.0.tgz",
+      "integrity": "sha512-o0cTQdMqHh4ERDLtjUp1/KGPbQoNwKRxUh6f8+KQyjC5DSmiw/r+jgFe/WHh067aW+WU8nA9Ytw9ag7OhzxEkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.74.0.tgz",
+      "integrity": "sha512-IEMM/V6gKdP+N/X31KDIczVzghDpiPWFGLNjS8Rus71KvV6y6ueLrrE/JGCHDrU+9pq5copF3iCa0YQh+9Lq9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.74.0",
+        "@supabase/functions-js": "2.74.0",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "2.74.0",
+        "@supabase/realtime-js": "2.74.0",
+        "@supabase/storage-js": "2.74.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1260,13 +1335,16 @@
       "version": "24.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -1299,6 +1377,15 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -4235,6 +4322,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -4280,10 +4373,7 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
       "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -4498,6 +4588,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4610,6 +4716,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.3",
+    "@supabase/supabase-js": "^2.74.0",
     "clsx": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -22,7 +22,8 @@ import {
   deleteAgentConversation,
   fetchAgentConversations,
   mapConversationToChat,
-  upsertAgentConversation
+  upsertAgentConversation,
+  type AgentConversationUpdatePayload
 } from '../services/chatService';
 import {
   applyIntegrationSecretToSettings,
@@ -211,7 +212,8 @@ export function ChatPage() {
                 agentName,
                 agentDescription: agent.description ?? '',
                 agentAvatarUrl: agent.avatarUrl ?? null,
-                agentWebhookUrl: agent.webhookUrl ?? null
+                agentWebhookUrl: agent.webhookUrl ?? null,
+                agentTools: agent.tools
               })
             );
             return;
@@ -220,7 +222,7 @@ export function ChatPage() {
           const chat = mapConversationToChat(record, agentName, defaultPreview);
           nextConversations[agentId] = chat;
 
-          const metadataUpdates: Record<string, string | null> = {};
+          const metadataUpdates: AgentConversationUpdatePayload = {};
           if (record.agent_name !== agentName) {
             metadataUpdates.agentName = agentName;
           }
@@ -232,6 +234,15 @@ export function ChatPage() {
           }
           if ((record.agent_webhook_url ?? null) !== (agent.webhookUrl ?? null)) {
             metadataUpdates.agentWebhookUrl = agent.webhookUrl ?? null;
+          }
+          const existingTools = record.agent_tools ?? [];
+          const desiredTools = agent.tools ?? [];
+          const toolsChanged =
+            existingTools.length !== desiredTools.length ||
+            existingTools.some((tool, index) => tool !== desiredTools[index]);
+
+          if (toolsChanged) {
+            metadataUpdates.agentTools = desiredTools;
           }
 
           if (Object.keys(metadataUpdates).length > 0) {
@@ -396,7 +407,8 @@ export function ChatPage() {
           agentName: chat.name,
           agentDescription: selectedAgent.description ?? '',
           agentAvatarUrl: selectedAgent.avatarUrl ?? null,
-          agentWebhookUrl: selectedAgent.webhookUrl ?? null
+          agentWebhookUrl: selectedAgent.webhookUrl ?? null,
+          agentTools: selectedAgent.tools
         });
       } catch (error) {
         console.error('Initiale Konversation konnte nicht gespeichert werden.', error);
@@ -480,7 +492,8 @@ export function ChatPage() {
         agentName: chatAfterUserMessage.name,
         agentDescription: selectedAgent.description ?? '',
         agentAvatarUrl: selectedAgent.avatarUrl ?? null,
-        agentWebhookUrl: selectedAgent.webhookUrl ?? null
+        agentWebhookUrl: selectedAgent.webhookUrl ?? null,
+        agentTools: selectedAgent.tools
       });
     } catch (error) {
       console.error('Nachricht konnte nicht gespeichert werden.', error);
@@ -540,7 +553,8 @@ export function ChatPage() {
           agentName: chatAfterAgent.name,
           agentDescription: selectedAgent.description ?? '',
           agentAvatarUrl: selectedAgent.avatarUrl ?? null,
-          agentWebhookUrl: selectedAgent.webhookUrl ?? null
+          agentWebhookUrl: selectedAgent.webhookUrl ?? null,
+          agentTools: selectedAgent.tools
         });
       } catch (persistError) {
         console.error('Antwort konnte nicht gespeichert werden.', persistError);
@@ -578,7 +592,8 @@ export function ChatPage() {
           agentName: chatWithError.name,
           agentDescription: selectedAgent.description ?? '',
           agentAvatarUrl: selectedAgent.avatarUrl ?? null,
-          agentWebhookUrl: selectedAgent.webhookUrl ?? null
+          agentWebhookUrl: selectedAgent.webhookUrl ?? null,
+          agentTools: selectedAgent.tools
         });
       } catch (persistError) {
         console.error('Fehlernachricht konnte nicht gespeichert werden.', persistError);

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,0 +1,12 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.warn('Supabase-Umgebungsvariablen sind nicht vollständig gesetzt.');
+}
+
+export const supabase = createClient(supabaseUrl ?? '', supabaseKey ?? '');
+
+export default supabase;


### PR DESCRIPTION
## Summary
- add a Supabase client helper and dependency to configure the app against the hosted project
- migrate the authentication context to Supabase for sign-in, registration, profile, and agent lifecycle management with RLS-aware profile creation
- persist agent conversations in Supabase and keep chat metadata, including agent tools, synchronised from the chat page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6a304e9bc832485f112070bf4213e