### PR TITLE
Enhance auth experience with cached session, drafts, and toasts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.1.3",
         "@supabase/supabase-js": "^2.74.0",
+        "audio-recorder-polyfill": "^0.4.1",
         "clsx": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1466,6 +1467,12 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/audio-recorder-polyfill": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/audio-recorder-polyfill/-/audio-recorder-polyfill-0.4.1.tgz",
+      "integrity": "sha512-SS4qVOzuVwlS/tjQdd0uR+9cCKBTkx4jsAdjM+rMNqoTEWf6bMnBSTfv+FO4Zn9ngxviJOxhkgRWWXsAMqM96Q==",
       "license": "MIT"
     },
     "node_modules/autoprefixer": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@heroicons/react": "^2.1.3",
     "@supabase/supabase-js": "^2.74.0",
+    "audio-recorder-polyfill": "^0.4.1",
     "clsx": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/ChatOverviewPanel.tsx
+++ b/src/components/ChatOverviewPanel.tsx
@@ -105,14 +105,25 @@ export function ChatOverviewPanel({
   );
 
   return (
-    <aside
-      className={clsx(
-        'relative hidden w-full max-w-md flex-col border-r border-white/5 bg-[#161616]/70 backdrop-blur-xl lg:flex',
-        isMobileOpen && 'fixed inset-y-0 left-0 z-40 block max-w-sm'
+    <>
+      <aside
+        className={clsx(
+          'relative w-full max-w-md flex-col border-r border-white/5 bg-[#161616]/70 backdrop-blur-xl transition-all duration-300',
+          isMobileOpen ? 'fixed inset-y-0 left-0 z-40 flex max-w-sm shadow-2xl lg:relative lg:flex lg:max-w-md' : 'hidden lg:flex'
+        )}
+      >
+        <div className="absolute inset-0 bg-[#161616]/80" />
+        <div className="relative flex h-full flex-col">{PanelContent}</div>
+      </aside>
+
+      {isMobileOpen && (
+        <button
+          type="button"
+          aria-label="Workspace schließen"
+          onClick={onCloseMobile}
+          className="fixed inset-0 z-30 bg-black/50 backdrop-blur-sm transition-opacity lg:hidden"
+        />
       )}
-    >
-      <div className="absolute inset-0 bg-[#161616]/80" />
-      <div className="relative flex h-full flex-col">{PanelContent}</div>
-    </aside>
+    </>
   );
 }

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,3 +1,4 @@
+import { ArrowPathIcon } from '@heroicons/react/24/outline';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
@@ -6,9 +7,48 @@ export function RequireAuth() {
   const location = useLocation();
 
   if (isLoading) {
+    const initials = currentUser?.name
+      ? currentUser.name
+          .split(' ')
+          .map((part) => part.trim()[0])
+          .filter(Boolean)
+          .slice(0, 2)
+          .join('')
+          .toUpperCase()
+      : null;
+
     return (
       <div className="flex min-h-screen items-center justify-center bg-[#111111] px-4 text-white/70">
-        <p className="text-sm">Authentifizierung wird geladen …</p>
+        <div className="w-full max-w-sm rounded-3xl border border-white/10 bg-[#161616] p-8 text-center shadow-glow">
+          <ArrowPathIcon className="mx-auto h-6 w-6 animate-spin text-white/70" />
+          {currentUser ? (
+            <>
+              <p className="mt-4 text-sm text-white/60">Willkommen zurück</p>
+              <div className="mt-4 flex items-center justify-center gap-3">
+                {currentUser.avatarUrl ? (
+                  <span className="h-12 w-12 overflow-hidden rounded-full border border-white/10 bg-white/10">
+                    <img
+                      src={currentUser.avatarUrl}
+                      alt="Profilbild"
+                      className="h-full w-full object-cover"
+                    />
+                  </span>
+                ) : (
+                  <span className="flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/10 text-sm font-semibold uppercase text-white/70">
+                    {initials || 'AI'}
+                  </span>
+                )}
+                <div className="text-left">
+                  <p className="text-base font-semibold text-white">{currentUser.name}</p>
+                  <p className="text-xs text-white/40">{currentUser.email}</p>
+                </div>
+              </div>
+              <p className="mt-4 text-xs text-white/50">Dein Arbeitsbereich wird vorbereitet …</p>
+            </>
+          ) : (
+            <p className="mt-4 text-sm">Authentifizierung wird geladen …</p>
+          )}
+        </div>
       </div>
     );
   }

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -241,7 +241,6 @@ const ensureProfileForUser = async (user: User, preferredName?: string) => {
     id: user.id,
     email: user.email ?? '',
     display_name: normalizedName,
-    name: normalizedName,
     avatar_url: avatar,
     role: 'user',
     bio: '',
@@ -513,7 +512,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (typeof updates.name === 'string') {
         const trimmed = updates.name.trim();
         payload.display_name = trimmed.length > 0 ? trimmed : currentUser.name;
-        payload.name = trimmed.length > 0 ? trimmed : currentUser.name;
       }
 
       if ('avatarUrl' in updates) {

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -142,19 +142,19 @@ const mapProfileRowToAuthUser = (
     emailVerified?: boolean;
   }
 ): AuthUser => {
-  const fallbackName = fallback?.name && fallback.name.trim().length > 0 ? fallback.name.trim() : null;
-  const fallbackEmail = fallback?.email ?? '';
+  const normalizedDisplayName = row.display_name?.trim().length ? row.display_name.trim() : null;
+  const normalizedEmail = row.email?.trim().length ? row.email.trim() : null;
+  const fallbackNameTrimmed = fallback?.name?.trim();
+  const fallbackEmailTrimmed = fallback?.email?.trim();
+  const fallbackName = fallbackNameTrimmed && fallbackNameTrimmed.length > 0 ? fallbackNameTrimmed : null;
+  const fallbackEmail = fallbackEmailTrimmed && fallbackEmailTrimmed.length > 0 ? fallbackEmailTrimmed : null;
   const fallbackAvatar = fallback?.avatarUrl ?? null;
   const fallbackEmailVerified = fallback?.emailVerified ?? false;
 
   return {
     id: row.id,
-    name:
-      (row.display_name?.trim().length ? row.display_name.trim() : null) ??
-      fallbackName ??
-      fallbackEmail ??
-      'Neuer Nutzer',
-    email: row.email ?? fallbackEmail,
+    name: normalizedDisplayName ?? fallbackName ?? fallbackEmail ?? 'Neuer Nutzer',
+    email: normalizedEmail ?? fallbackEmail ?? '',
     role: row.role === 'admin' ? 'admin' : 'user',
     isActive: row.is_active ?? true,
     avatarUrl: row.avatar_url ?? fallbackAvatar,

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -147,12 +147,13 @@ const mapProfileRowToAuthUser = (
   const fallbackAvatar = fallback?.avatarUrl ?? null;
   const fallbackEmailVerified = fallback?.emailVerified ?? false;
 
-  const preferredName = row.display_name?.trim().length ? row.display_name.trim() : null;
-  const secondaryName = row.name?.trim().length ? row.name.trim() : null;
-
   return {
     id: row.id,
-    name: preferredName ?? secondaryName ?? fallbackName ?? fallbackEmail ?? 'Neuer Nutzer',
+    name:
+      (row.display_name?.trim().length ? row.display_name.trim() : null) ??
+      fallbackName ??
+      fallbackEmail ??
+      'Neuer Nutzer',
     email: row.email ?? fallbackEmail,
     role: row.role === 'admin' ? 'admin' : 'user',
     isActive: row.is_active ?? true,
@@ -300,7 +301,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           if (isRowLevelSecurityError(agentsError)) {
             const fallbackUsers = (profileRows ?? []).map((row) =>
               mapProfileRowToAuthUser(row as ProfileRow, [], {
-                name: row.display_name ?? row.name ?? undefined,
+                name: row.display_name ?? undefined,
                 email: row.email ?? undefined,
                 avatarUrl: row.avatar_url ?? undefined
               })
@@ -322,7 +323,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         const nextUsers = (profileRows ?? []).map((row) =>
           mapProfileRowToAuthUser(row as ProfileRow, agentsByProfile.get(row.id) ?? [], {
-            name: row.display_name ?? row.name ?? undefined,
+            name: row.display_name ?? undefined,
             email: row.email ?? undefined,
             avatarUrl: row.avatar_url ?? undefined
           })

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -1,0 +1,184 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode
+} from 'react';
+import { createPortal } from 'react-dom';
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  InformationCircleIcon,
+  XMarkIcon
+} from '@heroicons/react/24/outline';
+import clsx from 'clsx';
+
+type ToastType = 'success' | 'error' | 'info';
+
+interface ShowToastOptions {
+  type?: ToastType;
+  title: string;
+  description?: string;
+  duration?: number;
+}
+
+interface Toast extends Required<ShowToastOptions> {
+  id: string;
+  createdAt: number;
+}
+
+interface ToastContextValue {
+  showToast: (options: ShowToastOptions) => string;
+  dismissToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+const DEFAULT_DURATION = 4000;
+const MAX_TOASTS = 4;
+
+function createToastIcon(type: ToastType) {
+  switch (type) {
+    case 'success':
+      return <CheckCircleIcon className="h-5 w-5 text-emerald-300" aria-hidden="true" />;
+    case 'error':
+      return <ExclamationTriangleIcon className="h-5 w-5 text-rose-300" aria-hidden="true" />;
+    default:
+      return <InformationCircleIcon className="h-5 w-5 text-sky-300" aria-hidden="true" />;
+  }
+}
+
+function generateToastId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `toast-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timeoutsRef = useRef<Map<string, number>>(new Map());
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((previous) => previous.filter((toast) => toast.id !== id));
+    if (typeof window !== 'undefined') {
+      const timeoutId = timeoutsRef.current.get(id);
+      if (typeof timeoutId === 'number') {
+        window.clearTimeout(timeoutId);
+        timeoutsRef.current.delete(id);
+      }
+    }
+  }, []);
+
+  const showToast = useCallback(
+    ({ type = 'info', title, description, duration = DEFAULT_DURATION }: ShowToastOptions) => {
+      const id = generateToastId();
+      const toast: Toast = {
+        id,
+        type,
+        title,
+        description: description ?? '',
+        duration,
+        createdAt: Date.now()
+      };
+
+      setToasts((previous) => {
+        const existing = previous.filter((entry) => entry.id !== id);
+        const limited = existing.slice(-MAX_TOASTS + 1);
+        return [...limited, toast];
+      });
+
+      if (typeof window !== 'undefined') {
+        const timeoutId = window.setTimeout(() => {
+          dismissToast(id);
+        }, duration);
+        timeoutsRef.current.set(id, timeoutId);
+      }
+
+      return id;
+    },
+    [dismissToast]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      timeoutsRef.current.forEach((timeoutId) => {
+        window.clearTimeout(timeoutId);
+      });
+      timeoutsRef.current.clear();
+    };
+  }, []);
+
+  const value = useMemo<ToastContextValue>(
+    () => ({
+      showToast,
+      dismissToast
+    }),
+    [dismissToast, showToast]
+  );
+
+  const portal =
+    typeof document !== 'undefined'
+      ? createPortal(
+          <div className="pointer-events-none fixed inset-0 z-[1000] flex flex-col items-end gap-3 p-4 sm:p-6">
+            {toasts.map((toast) => (
+              <div
+                key={toast.id}
+                className={clsx(
+                  'pointer-events-auto w-full max-w-sm overflow-hidden rounded-2xl border px-4 py-3 shadow-glow transition sm:max-w-md',
+                  toast.type === 'success' && 'border-emerald-500/40 bg-emerald-500/10',
+                  toast.type === 'error' && 'border-rose-500/40 bg-rose-500/10',
+                  toast.type === 'info' && 'border-sky-500/40 bg-sky-500/10'
+                )}
+                role="status"
+                aria-live="polite"
+              >
+                <div className="flex items-start gap-3">
+                  <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-black/20">
+                    {createToastIcon(toast.type)}
+                  </div>
+                  <div className="flex-1 text-left text-sm text-white">
+                    <p className="font-semibold">{toast.title}</p>
+                    {toast.description && <p className="mt-1 text-xs text-white/70">{toast.description}</p>}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => dismissToast(toast.id)}
+                    className="text-white/60 transition hover:text-white"
+                    aria-label="Benachrichtigung schließen"
+                  >
+                    <XMarkIcon className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>,
+          document.body
+        )
+      : null;
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      {portal}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast muss innerhalb eines ToastProvider verwendet werden.');
+  }
+
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import './styles/global.css';
 import { loadAgentSettings } from './utils/storage';
 import { applyColorScheme } from './utils/theme';
 import { AuthProvider } from './context/AuthContext';
+import { ToastProvider } from './context/ToastContext';
 
 if (typeof window !== 'undefined') {
   const initialSettings = loadAgentSettings();
@@ -15,9 +16,11 @@ if (typeof window !== 'undefined') {
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter basename="/agent">
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      <ToastProvider>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </ToastProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -106,7 +106,9 @@ export function ProfilePage() {
 
     const storedDraft = loadProfileDraft(currentUser.id);
     if (storedDraft) {
-      setName(storedDraft.name);
+      const draftName = storedDraft.name?.trim().length ? storedDraft.name : null;
+      const fallbackName = currentUser.name.trim().length > 0 ? currentUser.name : 'Neuer Nutzer';
+      setName(draftName ?? fallbackName);
       setBio(storedDraft.bio);
       setAvatarPreview(
         typeof storedDraft.avatarUrl === 'string' && storedDraft.avatarUrl.length > 0
@@ -114,7 +116,8 @@ export function ProfilePage() {
           : currentUser.avatarUrl ?? null
       );
     } else {
-      setName(currentUser.name);
+      const fallbackName = currentUser.name.trim().length > 0 ? currentUser.name : 'Neuer Nutzer';
+      setName(fallbackName);
       setBio(currentUser.bio ?? '');
       setAvatarPreview(currentUser.avatarUrl ?? null);
     }

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import {
   ArrowLeftIcon,
@@ -13,7 +13,14 @@ import clsx from 'clsx';
 import { useAuth } from '../context/AuthContext';
 import { AgentProfile } from '../types/auth';
 import { AgentSettings, toSettingsEventPayload } from '../types/settings';
-import { loadAgentSettings, saveAgentSettings } from '../utils/storage';
+import {
+  loadAgentDraft,
+  loadAgentSettings,
+  loadProfileDraft,
+  saveAgentDraft,
+  saveAgentSettings,
+  saveProfileDraft
+} from '../utils/storage';
 import { applyColorScheme } from '../utils/theme';
 import { sendWebhookMessage } from '../utils/webhook';
 import { prepareImageForStorage } from '../utils/image';
@@ -23,6 +30,7 @@ import {
 } from '../services/integrationSecretsService';
 import userAvatar from '../assets/default-user.svg';
 import agentFallbackAvatar from '../assets/agent-avatar.png';
+import { useToast } from '../context/ToastContext';
 
 interface AgentFormState {
   name: string;
@@ -55,16 +63,20 @@ export function ProfilePage() {
   } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const [name, setName] = useState(currentUser?.name ?? '');
-  const [bio, setBio] = useState(currentUser?.bio ?? '');
-  const [avatarPreview, setAvatarPreview] = useState<string | null>(currentUser?.avatarUrl ?? null);
+  const { showToast } = useToast();
+  const [name, setName] = useState('');
+  const [bio, setBio] = useState('');
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
-  const [feedback, setFeedback] = useState<'success' | 'error' | null>(null);
   const [redirectAfterSave, setRedirectAfterSave] = useState(() =>
     Boolean((location.state as { onboarding?: boolean } | null)?.onboarding)
   );
   const [agentModal, setAgentModal] = useState<AgentModalState | null>(null);
   const [agentForm, setAgentForm] = useState<AgentFormState>(() => createEmptyAgentForm());
+  const agentCreateDraftRef = useRef<AgentFormState>(createEmptyAgentForm());
+  const profileDraftInitializedRef = useRef(false);
+  const agentDraftInitializedRef = useRef(false);
+  const agentDraftUserRef = useRef<string | null>(null);
   const [agentSaving, setAgentSaving] = useState(false);
   const [agentError, setAgentError] = useState<string | null>(null);
   const [agentSettings, setAgentSettings] = useState<AgentSettings>(() => loadAgentSettings());
@@ -82,6 +94,113 @@ export function ProfilePage() {
   const displayedAvatar = avatarPreview ?? userAvatar;
   const userAgents = currentUser.agents;
   const agentAvatarPreview = agentForm.avatarUrl ?? agentFallbackAvatar;
+
+  useEffect(() => {
+    if (!currentUser) {
+      setName('');
+      setBio('');
+      setAvatarPreview(null);
+      profileDraftInitializedRef.current = false;
+      return;
+    }
+
+    const storedDraft = loadProfileDraft(currentUser.id);
+    if (storedDraft) {
+      setName(storedDraft.name);
+      setBio(storedDraft.bio);
+      setAvatarPreview(
+        typeof storedDraft.avatarUrl === 'string' && storedDraft.avatarUrl.length > 0
+          ? storedDraft.avatarUrl
+          : currentUser.avatarUrl ?? null
+      );
+    } else {
+      setName(currentUser.name);
+      setBio(currentUser.bio ?? '');
+      setAvatarPreview(currentUser.avatarUrl ?? null);
+    }
+
+    profileDraftInitializedRef.current = true;
+  }, [currentUser]);
+
+  useEffect(() => {
+    if (!currentUser || !profileDraftInitializedRef.current) {
+      return;
+    }
+
+    const normalizedName = name.trim();
+    const baselineName = (currentUser.name ?? '').trim();
+    const baselineBio = currentUser.bio ?? '';
+    const baselineAvatar = currentUser.avatarUrl ?? null;
+    const nextDraft = {
+      name,
+      bio,
+      avatarUrl: avatarPreview
+    };
+
+    const hasChanges =
+      normalizedName !== baselineName || bio !== baselineBio || (avatarPreview ?? null) !== baselineAvatar;
+
+    if (hasChanges) {
+      saveProfileDraft(currentUser.id, nextDraft);
+    } else {
+      saveProfileDraft(currentUser.id, null);
+    }
+  }, [avatarPreview, bio, currentUser, name]);
+
+  useEffect(() => {
+    if (!currentUser) {
+      agentDraftInitializedRef.current = false;
+      agentDraftUserRef.current = null;
+      const emptyDraft = createEmptyAgentForm();
+      agentCreateDraftRef.current = emptyDraft;
+      setAgentForm(emptyDraft);
+      return;
+    }
+
+    if (agentDraftInitializedRef.current && agentDraftUserRef.current === currentUser.id) {
+      return;
+    }
+
+    const storedDraft = loadAgentDraft(currentUser.id);
+    const nextDraft: AgentFormState = storedDraft
+      ? {
+          name: storedDraft.name,
+          description: storedDraft.description,
+          tools: storedDraft.tools,
+          webhookUrl: storedDraft.webhookUrl,
+          avatarUrl: storedDraft.avatarUrl
+        }
+      : createEmptyAgentForm();
+
+    agentCreateDraftRef.current = nextDraft;
+    if (!agentModal || agentModal.mode !== 'edit') {
+      setAgentForm(nextDraft);
+    }
+
+    agentDraftInitializedRef.current = true;
+    agentDraftUserRef.current = currentUser.id;
+  }, [agentModal, currentUser]);
+
+  useEffect(() => {
+    if (!currentUser || !agentDraftInitializedRef.current || agentModal?.mode === 'edit') {
+      return;
+    }
+
+    agentCreateDraftRef.current = agentForm;
+
+    const hasContent =
+      agentForm.name.trim().length > 0 ||
+      agentForm.description.trim().length > 0 ||
+      agentForm.tools.trim().length > 0 ||
+      agentForm.webhookUrl.trim().length > 0 ||
+      Boolean(agentForm.avatarUrl);
+
+    if (hasContent) {
+      saveAgentDraft(currentUser.id, agentForm);
+    } else {
+      saveAgentDraft(currentUser.id, null);
+    }
+  }, [agentForm, agentModal?.mode, currentUser]);
 
   useEffect(() => {
     applyColorScheme(agentSettings.colorScheme);
@@ -134,7 +253,7 @@ export function ProfilePage() {
   useEffect(() => {
     const state = location.state as { onboarding?: boolean; openAgentModal?: 'create' } | null;
     if (state?.openAgentModal === 'create') {
-      setAgentForm(createEmptyAgentForm());
+      setAgentForm(agentCreateDraftRef.current ?? createEmptyAgentForm());
       setAgentModal({ mode: 'create' });
       setAgentError(null);
       setAgentWebhookTestStatus('idle');
@@ -160,7 +279,11 @@ export function ProfilePage() {
       setAvatarPreview(result);
     } catch (error) {
       console.error('Profilbild konnte nicht verarbeitet werden.', error);
-      setFeedback('error');
+      showToast({
+        type: 'error',
+        title: 'Profilbild konnte nicht verarbeitet werden',
+        description: 'Bitte versuche es mit einer anderen Datei.'
+      });
     }
   };
 
@@ -170,7 +293,7 @@ export function ProfilePage() {
   };
 
   const openCreateAgentModal = () => {
-    setAgentForm(createEmptyAgentForm());
+    setAgentForm(agentCreateDraftRef.current ?? createEmptyAgentForm());
     setAgentModal({ mode: 'create' });
     setAgentError(null);
     resetAgentWebhookTest();
@@ -189,11 +312,30 @@ export function ProfilePage() {
     resetAgentWebhookTest();
   };
 
-  const closeAgentModal = () => {
+  const closeAgentModal = (options?: { resetDraft?: boolean }) => {
+    const previousModal = agentModal;
     setAgentModal(null);
     setAgentError(null);
-    setAgentForm(createEmptyAgentForm());
     resetAgentWebhookTest();
+
+    if (!previousModal) {
+      return;
+    }
+
+    if (previousModal.mode === 'create') {
+      if (options?.resetDraft) {
+        const emptyDraft = createEmptyAgentForm();
+        agentCreateDraftRef.current = emptyDraft;
+        setAgentForm(emptyDraft);
+        if (currentUser) {
+          saveAgentDraft(currentUser.id, null);
+        }
+      } else {
+        setAgentForm(agentCreateDraftRef.current);
+      }
+    } else if (previousModal.mode === 'edit') {
+      setAgentForm(agentCreateDraftRef.current);
+    }
   };
 
   const handleDeleteAgent = async (agentId: string) => {
@@ -204,12 +346,24 @@ export function ProfilePage() {
       }
     }
 
+    const agentToRemove = currentUser.agents.find((agent) => agent.id === agentId);
+
     try {
       await removeAgent(agentId);
+      showToast({
+        type: 'success',
+        title: 'Agent gelöscht',
+        description: agentToRemove?.name ? `${agentToRemove.name} wurde entfernt.` : 'Agent wurde entfernt.'
+      });
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Agent konnte nicht gelöscht werden.';
       setAgentError(message);
+      showToast({
+        type: 'error',
+        title: 'Agent konnte nicht gelöscht werden',
+        description: message
+      });
     }
   };
 
@@ -234,21 +388,38 @@ export function ProfilePage() {
   const performToggleUserActive = async (userId: string, nextActive: boolean) => {
     setAdminError(null);
 
+    const affectedUser =
+      users.find((user) => user.id === userId) ?? (currentUser.id === userId ? currentUser : null);
+
     try {
       await toggleUserActive(userId, nextActive);
+      showToast({
+        type: 'success',
+        title: nextActive ? 'Nutzer aktiviert' : 'Nutzer deaktiviert',
+        description: affectedUser
+          ? `${affectedUser.name} wurde ${nextActive ? 'aktiviert' : 'deaktiviert'}.`
+          : 'Status wurde aktualisiert.'
+      });
     } catch (error) {
       const message =
         error instanceof Error
           ? error.message
           : 'Nutzerstatus konnte nicht aktualisiert werden.';
       setAdminError(message);
+      showToast({
+        type: 'error',
+        title: 'Nutzerstatus konnte nicht aktualisiert werden',
+        description: message
+      });
     }
   };
 
   const handleAgentSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (!agentModal) {
+    const activeModal = agentModal;
+
+    if (!activeModal) {
       return;
     }
 
@@ -261,7 +432,7 @@ export function ProfilePage() {
       .filter((tool) => tool.length > 0);
 
     try {
-      if (agentModal.mode === 'create') {
+      if (activeModal.mode === 'create') {
         await addAgent({
           name: agentForm.name,
           description: agentForm.description,
@@ -269,21 +440,39 @@ export function ProfilePage() {
           tools,
           webhookUrl: agentForm.webhookUrl
         });
+        const draftName = agentForm.name.trim().length > 0 ? agentForm.name.trim() : 'Neuer Agent';
+        closeAgentModal({ resetDraft: true });
+        showToast({
+          type: 'success',
+          title: 'Agent erstellt',
+          description: `${draftName} wurde gespeichert.`
+        });
       } else {
-        await updateAgent(agentModal.agent.id, {
+        await updateAgent(activeModal.agent.id, {
           name: agentForm.name,
           description: agentForm.description,
           avatarUrl: agentForm.avatarUrl,
           tools,
           webhookUrl: agentForm.webhookUrl
         });
+        const updatedName =
+          agentForm.name.trim().length > 0 ? agentForm.name.trim() : activeModal.agent.name;
+        closeAgentModal();
+        showToast({
+          type: 'success',
+          title: 'Agent aktualisiert',
+          description: `${updatedName} wurde aktualisiert.`
+        });
       }
-
-      closeAgentModal();
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Agent konnte nicht gespeichert werden.';
       setAgentError(message);
+      showToast({
+        type: 'error',
+        title: 'Agent konnte nicht gespeichert werden',
+        description: message
+      });
     } finally {
       setAgentSaving(false);
     }
@@ -291,8 +480,12 @@ export function ProfilePage() {
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    if (!currentUser) {
+      return;
+    }
+
     setIsSaving(true);
-    setFeedback(null);
 
     try {
       await updateProfile({
@@ -300,17 +493,27 @@ export function ProfilePage() {
         bio,
         avatarUrl: avatarPreview
       });
-      setFeedback('success');
+      saveProfileDraft(currentUser.id, null);
+      showToast({
+        type: 'success',
+        title: 'Profil aktualisiert',
+        description: 'Deine Änderungen wurden gespeichert.'
+      });
       if (redirectAfterSave) {
         setRedirectAfterSave(false);
         setTimeout(() => navigate('/', { replace: true }), 600);
       }
     } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Profil konnte nicht aktualisiert werden.';
       console.error(error);
-      setFeedback('error');
+      showToast({
+        type: 'error',
+        title: 'Profil konnte nicht gespeichert werden',
+        description: message
+      });
     } finally {
       setIsSaving(false);
-      setTimeout(() => setFeedback(null), 4000);
     }
   };
 
@@ -628,17 +831,6 @@ export function ProfilePage() {
                 </div>
               </div>
 
-              {feedback === 'success' && (
-                <div className="rounded-2xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
-                  Profil aktualisiert!
-                </div>
-              )}
-              {feedback === 'error' && (
-                <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
-                  Aktualisierung fehlgeschlagen. Bitte versuche es später erneut.
-                </div>
-              )}
-
               <div className="flex flex-wrap items-center gap-3">
                 <button
                   type="submit"
@@ -779,7 +971,7 @@ export function ProfilePage() {
       {agentModal && (
         <div
           className="fixed inset-0 z-50 overflow-y-auto bg-black/60 px-4 py-10"
-          onClick={closeAgentModal}
+          onClick={() => closeAgentModal()}
         >
           <div className="mx-auto flex min-h-full w-full max-w-2xl items-center justify-center">
             <div
@@ -788,7 +980,7 @@ export function ProfilePage() {
             >
               <button
                 type="button"
-                onClick={closeAgentModal}
+                onClick={() => closeAgentModal()}
                 className="absolute right-5 top-5 rounded-full border border-white/10 p-2 text-white/60 transition hover:bg-white/10 hover:text-white"
               >
                 <XMarkIcon className="h-5 w-5" />
@@ -926,7 +1118,7 @@ export function ProfilePage() {
                 </button>
                 <button
                   type="button"
-                  onClick={closeAgentModal}
+                  onClick={() => closeAgentModal()}
                   className="text-sm text-white/50 hover:text-white"
                 >
                   Abbrechen

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -160,7 +160,17 @@ export function loadCachedAuthUser(): AuthUser | null {
 
     const parsed = JSON.parse(raw) as AuthUser & { cachedAt?: number };
     if (parsed && typeof parsed === 'object') {
-      return parsed;
+      const sanitizedName =
+        typeof parsed.name === 'string' && parsed.name.trim().length > 0
+          ? parsed.name.trim()
+          : typeof parsed.email === 'string' && parsed.email.trim().length > 0
+            ? parsed.email.trim()
+            : 'Neuer Nutzer';
+
+      return {
+        ...parsed,
+        name: sanitizedName
+      };
     }
 
     return null;


### PR DESCRIPTION
## Summary
- cache the last authenticated user in localStorage to hydrate the auth context quickly and show a personalized loading screen
- add a reusable toast provider and surface profile, agent, and admin actions through toasts instead of inline alerts
- persist profile and agent drafts locally so unfinished edits survive navigation and reloads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7a13e213c8324aa3c9defb8dada0f