### PR TITLE
feat: rebuild audio recording and delivery

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -7,19 +7,36 @@ import {
 import {
   ChangeEvent,
   FormEvent,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
   useState
 } from 'react';
 
+const RECORDING_MAX_DURATION_MS = 120_000;
+const WAVEFORM_BAR_COUNT = 24;
+const WAVEFORM_SAMPLE_INTERVAL_MS = 100;
+
+interface AudioPreview {
+  blob: Blob;
+  url: string;
+  mimeType: string;
+  durationMs: number;
+  waveform?: number[];
+}
+
+export interface AudioRecordingSubmission {
+  blob: Blob;
+  mimeType: string;
+  durationMs: number;
+  waveform?: number[];
+}
+
 export interface ChatInputSubmission {
   text: string;
   files: File[];
-  audio?: {
-    blob: Blob;
-    durationSeconds?: number | null;
-  };
+  audio?: AudioRecordingSubmission;
 }
 
 interface ChatInputProps {
@@ -39,6 +56,18 @@ const formatFileSize = (size: number) => {
   return `${size} B`;
 };
 
+const formatDuration = (durationMs: number) => {
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = (totalSeconds % 60).toString().padStart(2, '0');
+
+  return `${minutes}:${seconds}`;
+};
+
+const createInitialWaveform = () => Array.from({ length: WAVEFORM_BAR_COUNT }, () => 0);
+
 export function ChatInput({ onSendMessage, pushToTalkEnabled = true }: ChatInputProps) {
   const [message, setMessage] = useState('');
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
@@ -46,30 +75,102 @@ export function ChatInput({ onSendMessage, pushToTalkEnabled = true }: ChatInput
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
   const recorderMimeTypeRef = useRef<string | null>(null);
-  const [isRecording, setIsRecording] = useState(false);
-  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
-  const [audioUrl, setAudioUrl] = useState<string | null>(null);
-  const [audioDuration, setAudioDuration] = useState<number | null>(null);
   const recordingStartedAtRef = useRef<number | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserNodeRef = useRef<AnalyserNode | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
+  const timerIntervalRef = useRef<number | null>(null);
+  const maxDurationTimeoutRef = useRef<number | null>(null);
+  const waveformSamplesRef = useRef<number[]>([]);
+  const lastWaveSampleTimeRef = useRef<number>(0);
+
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordingDurationMs, setRecordingDurationMs] = useState(0);
+  const [waveformBars, setWaveformBars] = useState<number[]>(createInitialWaveform);
+  const [audioPreview, setAudioPreview] = useState<AudioPreview | null>(null);
   const [recordingError, setRecordingError] = useState<string | null>(null);
+  const [recordingUnsupported, setRecordingUnsupported] = useState(false);
+  const [isAudioSending, setIsAudioSending] = useState(false);
 
   const canSubmit = useMemo(() => {
-    return Boolean(message.trim() || selectedFiles.length > 0 || audioBlob);
-  }, [message, selectedFiles, audioBlob]);
+    return Boolean(message.trim() || selectedFiles.length > 0);
+  }, [message, selectedFiles]);
+
+  const cleanupRecordingResources = useCallback(() => {
+    if (animationFrameRef.current !== null) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+
+    if (timerIntervalRef.current !== null) {
+      window.clearInterval(timerIntervalRef.current);
+      timerIntervalRef.current = null;
+    }
+
+    if (maxDurationTimeoutRef.current !== null) {
+      window.clearTimeout(maxDurationTimeoutRef.current);
+      maxDurationTimeoutRef.current = null;
+    }
+
+    if (mediaStreamRef.current) {
+      mediaStreamRef.current.getTracks().forEach((track) => track.stop());
+      mediaStreamRef.current = null;
+    }
+
+    if (audioContextRef.current) {
+      void audioContextRef.current.close().catch(() => undefined);
+      audioContextRef.current = null;
+    }
+
+    analyserNodeRef.current = null;
+    lastWaveSampleTimeRef.current = 0;
+  }, []);
+
+  const resetAudioState = useCallback(() => {
+    cleanupRecordingResources();
+
+    audioChunksRef.current = [];
+    recorderMimeTypeRef.current = null;
+    recordingStartedAtRef.current = null;
+    waveformSamplesRef.current = [];
+
+    setIsRecording(false);
+    setRecordingDurationMs(0);
+    setWaveformBars(createInitialWaveform);
+
+    setAudioPreview((previous) => {
+      if (previous?.url) {
+        URL.revokeObjectURL(previous.url);
+      }
+
+      return null;
+    });
+  }, [cleanupRecordingResources]);
 
   useEffect(() => {
     return () => {
       if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
-        mediaRecorderRef.current.stop();
+        try {
+          mediaRecorderRef.current.stop();
+        } catch (error) {
+          console.error('Recorder konnte nicht gestoppt werden.', error);
+        }
       }
 
-      if (audioUrl) {
-        URL.revokeObjectURL(audioUrl);
+      cleanupRecordingResources();
+    };
+  }, [cleanupRecordingResources]);
+
+  useEffect(() => {
+    return () => {
+      if (audioPreview?.url) {
+        URL.revokeObjectURL(audioPreview.url);
       }
     };
-  }, [audioUrl]);
+  }, [audioPreview]);
 
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files ?? []);
@@ -85,50 +186,24 @@ export function ChatInput({ onSendMessage, pushToTalkEnabled = true }: ChatInput
     setSelectedFiles((prev) => prev.filter((_, fileIndex) => fileIndex !== index));
   };
 
-  const resetAudioState = () => {
-    if (audioUrl) {
-      URL.revokeObjectURL(audioUrl);
+  const ensureMediaRecorderSupport = async () => {
+    if (typeof window === 'undefined') {
+      return false;
     }
 
-    setAudioBlob(null);
-    setAudioUrl(null);
-    setAudioDuration(null);
-    recordingStartedAtRef.current = null;
-    recorderMimeTypeRef.current = null;
-  };
-
-  const stopRecording = () => {
-    if (!mediaRecorderRef.current) {
-      return;
+    if (typeof window.MediaRecorder !== 'undefined') {
+      return true;
     }
 
     try {
-      if (mediaRecorderRef.current.state !== 'inactive') {
-        mediaRecorderRef.current.stop();
-      }
+      const module = await import('audio-recorder-polyfill');
+      const AudioRecorderPolyfill = module.default ?? module;
+      (window as typeof window & { MediaRecorder: typeof MediaRecorder }).MediaRecorder =
+        AudioRecorderPolyfill as unknown as typeof MediaRecorder;
+      return true;
     } catch (error) {
-      console.error('Failed to stop recording', error);
-    }
-
-    setIsRecording(false);
-  };
-
-  const handleRecordingStop = () => {
-    const chunks = audioChunksRef.current;
-    const mimeType = recorderMimeTypeRef.current ?? 'audio/webm';
-    const blob = chunks.length ? new Blob(chunks, { type: mimeType }) : null;
-    audioChunksRef.current = [];
-    recorderMimeTypeRef.current = null;
-
-    if (blob) {
-      resetAudioState();
-      const objectUrl = URL.createObjectURL(blob);
-      setAudioBlob(blob);
-      setAudioUrl(objectUrl);
-      if (recordingStartedAtRef.current) {
-        const durationInSeconds = (Date.now() - recordingStartedAtRef.current) / 1000;
-        setAudioDuration(Number(durationInSeconds.toFixed(1)));
-      }
+      console.error('MediaRecorder Polyfill konnte nicht geladen werden.', error);
+      return false;
     }
   };
 
@@ -151,44 +226,101 @@ export function ChatInput({ onSendMessage, pushToTalkEnabled = true }: ChatInput
     throw new Error('unsupported');
   };
 
-  const ensureMediaRecorderSupport = async () => {
-    if (typeof window === 'undefined') {
-      return false;
+  const updateWaveformVisualization = useCallback(() => {
+    const analyser = analyserNodeRef.current;
+    if (!analyser) {
+      animationFrameRef.current = requestAnimationFrame(updateWaveformVisualization);
+      return;
     }
 
-    if (typeof window.MediaRecorder !== 'undefined') {
-      return true;
+    const bufferLength = analyser.fftSize;
+    const dataArray = new Uint8Array(bufferLength);
+    analyser.getByteTimeDomainData(dataArray);
+
+    let sum = 0;
+    for (let index = 0; index < dataArray.length; index += 1) {
+      sum += Math.abs(dataArray[index] - 128);
     }
 
-    try {
-      const module = await import('audio-recorder-polyfill');
-      const AudioRecorderPolyfill = module.default ?? module;
-      (window as typeof window & { MediaRecorder: any }).MediaRecorder = AudioRecorderPolyfill as unknown as typeof MediaRecorder;
-      return true;
-    } catch (error) {
-      console.error('Failed to load MediaRecorder polyfill', error);
-      return false;
-    }
-  };
+    const average = Math.min(255, (sum / dataArray.length) * 2);
+    const now = performance.now();
+    if (now - lastWaveSampleTimeRef.current >= WAVEFORM_SAMPLE_INTERVAL_MS) {
+      lastWaveSampleTimeRef.current = now;
+      waveformSamplesRef.current.push(average);
+      if (waveformSamplesRef.current.length > 256) {
+        waveformSamplesRef.current.shift();
+      }
 
-  const startRecording = async () => {
+      const recent = waveformSamplesRef.current.slice(-WAVEFORM_BAR_COUNT);
+      const padded = Array.from({ length: WAVEFORM_BAR_COUNT }, (_, index) => {
+        const value = recent[recent.length - WAVEFORM_BAR_COUNT + index];
+        return Number.isFinite(value) ? Math.max(0, Math.min(1, value / 255)) : 0;
+      });
+
+      setWaveformBars(padded);
+    }
+
+    animationFrameRef.current = requestAnimationFrame(updateWaveformVisualization);
+  }, []);
+
+  const handleRecorderStop = useCallback(() => {
+    cleanupRecordingResources();
+
+    const chunks = audioChunksRef.current;
+    audioChunksRef.current = [];
+    const mimeType = recorderMimeTypeRef.current ?? 'audio/webm';
+    recorderMimeTypeRef.current = null;
+
+    if (!chunks.length) {
+      setRecordingError('Es wurden keine Audiodaten aufgezeichnet.');
+      return;
+    }
+
+    const blob = new Blob(chunks, { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const startedAt = recordingStartedAtRef.current;
+    recordingStartedAtRef.current = null;
+    const duration = startedAt ? Date.now() - startedAt : recordingDurationMs;
+    const effectiveDuration = Math.min(RECORDING_MAX_DURATION_MS, Math.max(0, duration));
+    const waveform = waveformSamplesRef.current.slice();
+    waveformSamplesRef.current = [];
+    setWaveformBars(createInitialWaveform());
+
+    setAudioPreview({
+      blob,
+      url,
+      mimeType,
+      durationMs: effectiveDuration,
+      waveform: waveform.length ? waveform : undefined
+    });
+    setRecordingDurationMs(effectiveDuration);
+  }, [cleanupRecordingResources, recordingDurationMs]);
+
+  const startRecording = useCallback(async () => {
     if (!pushToTalkEnabled) {
       setRecordingError('Die Audioaufnahme ist in den Einstellungen deaktiviert.');
       return;
     }
 
-    if (isRecording) {
+    if (isRecording || isAudioSending) {
       return;
     }
 
+    setRecordingError(null);
+    setRecordingUnsupported(false);
+
     if (!(await ensureMediaRecorderSupport())) {
-      setRecordingError('Dein Browser unterstützt die benötigte Audioaufnahme-Schnittstelle nicht.');
+      setRecordingUnsupported(true);
+      setRecordingError('Audioaufnahme wird von deinem Browser nicht unterstützt.');
       return;
     }
 
     try {
-      setRecordingError(null);
       const stream = await requestAudioStream();
+      resetAudioState();
+      setRecordingDurationMs(0);
+
+      mediaStreamRef.current = stream;
 
       const supportedMimeType =
         typeof MediaRecorder.isTypeSupported === 'function'
@@ -197,43 +329,107 @@ export function ChatInput({ onSendMessage, pushToTalkEnabled = true }: ChatInput
             )
           : undefined;
 
-      const mediaRecorder = supportedMimeType
+      const recorder = supportedMimeType
         ? new MediaRecorder(stream, { mimeType: supportedMimeType })
         : new MediaRecorder(stream);
 
-      recorderMimeTypeRef.current = mediaRecorder.mimeType || supportedMimeType || null;
-      mediaRecorderRef.current = mediaRecorder;
-      audioChunksRef.current = [];
+      recorderMimeTypeRef.current = recorder.mimeType || supportedMimeType || null;
+      mediaRecorderRef.current = recorder;
       recordingStartedAtRef.current = Date.now();
+      waveformSamplesRef.current = [];
+      setWaveformBars(createInitialWaveform());
 
-      mediaRecorder.addEventListener('dataavailable', (event) => {
+      recorder.addEventListener('dataavailable', (event) => {
         if (event.data.size > 0) {
           audioChunksRef.current.push(event.data);
         }
       });
 
-      mediaRecorder.addEventListener('stop', () => {
-        stream.getTracks().forEach((track) => track.stop());
-        handleRecordingStop();
+      recorder.addEventListener('stop', () => {
+        mediaRecorderRef.current = null;
+        handleRecorderStop();
       });
 
-      mediaRecorder.start();
+      const AudioContextClass =
+        typeof window !== 'undefined'
+          ? (window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext })
+              .webkitAudioContext)
+          : null;
+
+      if (AudioContextClass) {
+        const audioContext = new AudioContextClass();
+        audioContextRef.current = audioContext;
+        const source = audioContext.createMediaStreamSource(stream);
+        const analyser = audioContext.createAnalyser();
+        analyser.fftSize = 512;
+        source.connect(analyser);
+        analyserNodeRef.current = analyser;
+        waveformSamplesRef.current = [];
+        lastWaveSampleTimeRef.current = 0;
+        animationFrameRef.current = requestAnimationFrame(updateWaveformVisualization);
+      } else {
+        analyserNodeRef.current = null;
+        waveformSamplesRef.current = [];
+        setWaveformBars(createInitialWaveform());
+      }
+
+      timerIntervalRef.current = window.setInterval(() => {
+        if (recordingStartedAtRef.current) {
+          setRecordingDurationMs(Date.now() - recordingStartedAtRef.current);
+        }
+      }, 200);
+
+      maxDurationTimeoutRef.current = window.setTimeout(() => {
+        stopRecording();
+      }, RECORDING_MAX_DURATION_MS);
+
+      recorder.start();
       setIsRecording(true);
     } catch (error) {
-      console.error('Audio recording failed', error);
+      console.error('Audioaufnahme konnte nicht gestartet werden.', error);
       setRecordingError(
         error instanceof Error && error.message === 'unsupported'
-          ? 'Dein Browser unterstützt keine Audioaufnahme.'
+          ? 'Audioaufnahme wird von deinem Browser nicht unterstützt.'
           : 'Audioaufnahme konnte nicht gestartet werden. Prüfe die Mikrofonrechte.'
       );
+
+      if (mediaStreamRef.current) {
+        mediaStreamRef.current.getTracks().forEach((track) => track.stop());
+        mediaStreamRef.current = null;
+      }
+      cleanupRecordingResources();
     }
-  };
+  }, [cleanupRecordingResources, handleRecorderStop, isAudioSending, isRecording, pushToTalkEnabled, resetAudioState, updateWaveformVisualization]);
+
+  const stopRecording = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (!recorder) {
+      cleanupRecordingResources();
+      setIsRecording(false);
+      return;
+    }
+
+    try {
+      if (recorder.state !== 'inactive') {
+        recorder.stop();
+      }
+    } catch (error) {
+      console.error('Aufnahme konnte nicht gestoppt werden.', error);
+      cleanupRecordingResources();
+    }
+
+    setIsRecording(false);
+  }, [cleanupRecordingResources]);
 
   const toggleRecording = () => {
+    if (isAudioSending) {
+      return;
+    }
+
     if (isRecording) {
       stopRecording();
     } else {
-      startRecording();
+      void startRecording();
     }
   };
 
@@ -250,13 +446,7 @@ export function ChatInput({ onSendMessage, pushToTalkEnabled = true }: ChatInput
       await Promise.resolve(
         onSendMessage({
           text: message.trim(),
-          files: selectedFiles,
-          audio: audioBlob
-            ? {
-                blob: audioBlob,
-                durationSeconds: audioDuration
-              }
-            : undefined
+          files: selectedFiles
         })
       );
 
@@ -265,19 +455,60 @@ export function ChatInput({ onSendMessage, pushToTalkEnabled = true }: ChatInput
       if (fileInputRef.current) {
         fileInputRef.current.value = '';
       }
-
-      resetAudioState();
     } finally {
       setIsSubmitting(false);
     }
   };
 
+  const handleReRecord = () => {
+    resetAudioState();
+    setRecordingError(null);
+  };
+
+  const handleSendAudio = async () => {
+    const currentPreview = audioPreview;
+    if (!currentPreview || isAudioSending) {
+      return;
+    }
+
+    setIsAudioSending(true);
+    setRecordingError(null);
+
+    try {
+      await Promise.resolve(
+        onSendMessage({
+          text: '',
+          files: [],
+          audio: {
+            blob: currentPreview.blob,
+            mimeType: currentPreview.mimeType,
+            durationMs: currentPreview.durationMs,
+            waveform: currentPreview.waveform
+          }
+        })
+      );
+      resetAudioState();
+    } catch (error) {
+      console.error('Audionachricht konnte nicht gesendet werden.', error);
+      const messageText =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Audionachricht konnte nicht gesendet werden.';
+      setRecordingError(messageText);
+    } finally {
+      setIsAudioSending(false);
+    }
+  };
+
+  const isRecordButtonDisabled =
+    isAudioSending || (!isRecording && (!pushToTalkEnabled || recordingUnsupported));
+
   return (
     <form
       onSubmit={handleSubmit}
-      className="relative mt-6 rounded-3xl border border-white/10 bg-[#1b1b1b]/80 backdrop-blur-2xl p-4 shadow-[0_0_40px_rgba(250,207,57,0.12)]"
+      className="relative mt-6 rounded-3xl border border-white/10 bg-[#1b1b1b]/80 backdrop-blur-2xl p-4 shadow-[0_0_40px_rgba(190,207,57,0.12)]"
     >
-      {(selectedFiles.length > 0 || audioBlob || recordingError) && (
+      {(selectedFiles.length > 0 || audioPreview || recordingError || isRecording || recordingUnsupported) && (
         <div className="mb-4 space-y-3">
           {selectedFiles.length > 0 && (
             <div className="flex flex-wrap gap-2">
@@ -304,31 +535,68 @@ export function ChatInput({ onSendMessage, pushToTalkEnabled = true }: ChatInput
             </div>
           )}
 
-          {audioBlob && (
-            <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-3 text-xs text-white/80">
+          {isRecording && (
+            <div className="space-y-3 rounded-2xl border border-rose-500/40 bg-rose-500/10 p-3 text-xs text-rose-100">
+              <div className="flex items-center justify-between">
+                <span className="uppercase tracking-[0.2em]">Aufnahme läuft …</span>
+                <span className="font-mono text-sm">{formatDuration(recordingDurationMs)}</span>
+              </div>
+              <div className="flex h-12 items-end gap-1">
+                {waveformBars.map((value, index) => (
+                  <span
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={index}
+                    className="flex-1 rounded-full bg-rose-200/70"
+                    style={{ height: `${Math.max(6, value * 100)}%` }}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {audioPreview && !isRecording && (
+            <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-3 text-xs text-white/80">
               <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2">
                   <MicrophoneIcon className="h-4 w-4 text-brand-gold" />
                   <span>Aufgenommene Audionachricht</span>
-                  {audioDuration ? <span className="text-white/40">{audioDuration}s</span> : null}
+                  <span className="text-white/50">{formatDuration(audioPreview.durationMs)}</span>
                 </div>
                 <button
                   type="button"
-                  onClick={resetAudioState}
+                  onClick={handleReRecord}
                   className="inline-flex items-center gap-1 rounded-full border border-white/10 px-2 py-1 text-[10px] uppercase tracking-[0.2em] text-white/60 transition hover:bg-white/10"
                 >
-                  Entfernen
+                  Neu aufnehmen
                 </button>
               </div>
-              {audioUrl ? (
-                <audio controls src={audioUrl} className="mt-1 w-full" />
-              ) : null}
+              <audio controls src={audioPreview.url} className="w-full" />
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={handleSendAudio}
+                  disabled={isAudioSending}
+                  className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-brand-gold via-brand-deep to-brand-gold px-4 py-2 text-xs font-semibold text-surface-base shadow-glow transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isAudioSending ? (
+                    <span className="inline-flex items-center gap-2">
+                      <span className="h-4 w-4 animate-spin rounded-full border-2 border-surface-base/80 border-t-transparent" />
+                      <span>Senden…</span>
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-2">
+                      <span>Senden</span>
+                      <PaperAirplaneIcon className="h-4 w-4" />
+                    </span>
+                  )}
+                </button>
+              </div>
             </div>
           )}
 
-          {recordingError && (
+          {(recordingError || recordingUnsupported) && (
             <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
-              {recordingError}
+              {recordingError ?? 'Audioaufnahme wird von deinem Browser nicht unterstützt.'}
             </div>
           )}
         </div>
@@ -341,12 +609,14 @@ export function ChatInput({ onSendMessage, pushToTalkEnabled = true }: ChatInput
           multiple
           onChange={handleFileChange}
           className="hidden"
+          disabled={isRecording}
         />
         <button
           type="button"
           onClick={() => fileInputRef.current?.click()}
-          className="group rounded-2xl bg-white/5 p-3 text-white/70 transition hover:bg-white/10"
+          className="group rounded-2xl bg-white/5 p-3 text-white/70 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
           title="Dateien anhängen"
+          disabled={isRecording}
         >
           <PaperClipIcon className="h-5 w-5 group-hover:text-white" />
         </button>
@@ -355,20 +625,29 @@ export function ChatInput({ onSendMessage, pushToTalkEnabled = true }: ChatInput
           value={message}
           onChange={(event) => setMessage(event.target.value)}
           placeholder="Nachricht an den Agent eingeben..."
-          className="min-w-0 flex-1 bg-transparent px-2 text-sm text-white placeholder:text-white/30 focus:outline-none"
+          className="min-w-0 flex-1 bg-transparent px-2 text-sm text-white placeholder:text-white/30 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isRecording}
         />
         <button
           type="button"
           onClick={toggleRecording}
-          disabled={!pushToTalkEnabled && !isRecording}
+          disabled={isRecordButtonDisabled}
           className={`group rounded-2xl p-3 transition ${
             isRecording
               ? 'bg-rose-500/20 text-rose-100'
-              : pushToTalkEnabled
-              ? 'bg-white/5 text-white/70 hover:bg-white/10'
-              : 'cursor-not-allowed bg-white/5 text-white/30'
-          }`}
-          title={pushToTalkEnabled ? 'Audio Nachricht aufnehmen' : 'Audioaufnahme deaktiviert'}
+              : !pushToTalkEnabled || recordingUnsupported
+              ? 'cursor-not-allowed bg-white/5 text-white/30'
+              : 'bg-white/5 text-white/70 hover:bg-white/10'
+          } ${isAudioSending ? 'opacity-60' : ''}`}
+          title={
+            pushToTalkEnabled
+              ? recordingUnsupported
+                ? 'Audioaufnahme nicht unterstützt'
+                : isRecording
+                ? 'Aufnahme stoppen'
+                : 'Audionachricht aufnehmen'
+              : 'Audioaufnahme deaktiviert'
+          }
         >
           <MicrophoneIcon className={`h-5 w-5 ${isRecording ? 'animate-pulse' : ''}`} />
         </button>

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -213,6 +213,7 @@ export function ChatInput({ onSendMessage, pushToTalkEnabled = true }: ChatInput
     }
 
     const legacyGetUserMedia =
+      (navigator as any).getUserMedia ||
       (navigator as any).webkitGetUserMedia ||
       (navigator as any).mozGetUserMedia ||
       (navigator as any).msGetUserMedia;

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -519,7 +519,6 @@ export function ChatPage() {
       const webhookResponse = audioRecording
         ? await (async () => {
             const uploadResult = await uploadAndPersistAudioMessage({
-              profileId: currentUser.id,
               conversationId: chatAfterUserMessage.id,
               recording: {
                 blob: audioRecording.blob,

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -643,7 +643,7 @@ export function ChatPage() {
   };
 
   return (
-    <div className="relative flex min-h-[100dvh] flex-col overflow-hidden bg-[#111111] text-white">
+    <div className="relative flex h-[100dvh] flex-col overflow-hidden bg-[#111111] text-white">
       <div className="flex flex-1 overflow-hidden">
         {(!isWorkspaceCollapsed || isMobileWorkspaceOpen) && (
           <ChatOverviewPanel

--- a/src/services/audioMessageService.ts
+++ b/src/services/audioMessageService.ts
@@ -1,0 +1,149 @@
+import supabase from '../utils/supabase';
+
+const AUDIO_BUCKET_NAME = 'audio';
+const DEFAULT_AUDIO_MIME = 'audio/webm';
+const MAX_WAVEFORM_VALUES = 128;
+
+export interface AudioRecordingPayload {
+  blob: Blob;
+  mimeType: string;
+  durationMs: number;
+  waveform?: number[];
+}
+
+export interface AudioMessageUploadResult {
+  messageId: string;
+  storagePath: string;
+  signedUrl: string;
+  meta: {
+    url: string;
+    path: string;
+    mime: string;
+    duration_ms: number;
+    waveform?: number[];
+  };
+}
+
+const sanitizeDuration = (durationMs: number): number => {
+  if (!Number.isFinite(durationMs)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.round(durationMs));
+};
+
+const sanitizeWaveform = (waveform?: number[]): number[] | undefined => {
+  if (!Array.isArray(waveform) || waveform.length === 0) {
+    return undefined;
+  }
+
+  const limited = waveform.slice(-MAX_WAVEFORM_VALUES);
+  const sanitized = limited
+    .map((value) => {
+      if (!Number.isFinite(value)) {
+        return null;
+      }
+
+      return Math.max(0, Math.min(255, Math.round(value)));
+    })
+    .filter((value): value is number => value !== null);
+
+  return sanitized.length > 0 ? sanitized : undefined;
+};
+
+const deriveExtensionFromMime = (mimeType: string): string => {
+  const normalized = mimeType.toLowerCase();
+
+  if (normalized.includes('webm')) {
+    return 'webm';
+  }
+
+  if (normalized.includes('mp4')) {
+    return 'mp4';
+  }
+
+  if (normalized.includes('mpeg') || normalized.includes('mp3')) {
+    return 'mp3';
+  }
+
+  if (normalized.includes('ogg')) {
+    return 'ogg';
+  }
+
+  const parts = normalized.split('/');
+  if (parts.length === 2 && parts[1]) {
+    return parts[1];
+  }
+
+  return 'webm';
+};
+
+export const uploadAndPersistAudioMessage = async ({
+  profileId,
+  conversationId,
+  recording
+}: {
+  profileId: string;
+  conversationId: string;
+  recording: AudioRecordingPayload;
+}): Promise<AudioMessageUploadResult> => {
+  const mimeType = recording.mimeType?.trim() || DEFAULT_AUDIO_MIME;
+  const durationMs = sanitizeDuration(recording.durationMs);
+  const waveform = sanitizeWaveform(recording.waveform);
+  const extension = deriveExtensionFromMime(mimeType);
+  const timestamp = Date.now();
+  const storagePath = `${AUDIO_BUCKET_NAME}/${profileId}/${conversationId}/${timestamp}.${extension}`;
+
+  const { error: uploadError } = await supabase.storage
+    .from(AUDIO_BUCKET_NAME)
+    .upload(storagePath, recording.blob, {
+      contentType: mimeType
+    });
+
+  if (uploadError) {
+    throw new Error(uploadError.message ?? 'Audio konnte nicht hochgeladen werden.');
+  }
+
+  const { data: signedUrlData, error: signedUrlError } = await supabase.storage
+    .from(AUDIO_BUCKET_NAME)
+    .createSignedUrl(storagePath, 900);
+
+  if (signedUrlError || !signedUrlData?.signedUrl) {
+    throw new Error(signedUrlError?.message ?? 'Signierte URL konnte nicht erstellt werden.');
+  }
+
+  const meta = {
+    url: signedUrlData.signedUrl,
+    path: storagePath,
+    mime: mimeType,
+    duration_ms: durationMs,
+    ...(waveform ? { waveform } : {})
+  };
+
+  const { data: insertedRow, error: insertError } = await supabase
+    .from('messages')
+    .insert({
+      profile_id: profileId,
+      conversation_id: conversationId,
+      type: 'audio',
+      content: null,
+      meta
+    })
+    .select('id')
+    .single();
+
+  if (insertError) {
+    throw new Error(insertError.message ?? 'Nachricht konnte nicht gespeichert werden.');
+  }
+
+  if (!insertedRow || typeof insertedRow.id !== 'string') {
+    throw new Error('Ungültige Antwort beim Speichern der Nachricht.');
+  }
+
+  return {
+    messageId: insertedRow.id,
+    storagePath,
+    signedUrl: signedUrlData.signedUrl,
+    meta
+  };
+};


### PR DESCRIPTION
## Summary
- redesign the chat input to support toggle audio recordings with waveform, preview, and send controls
- persist audio messages in Supabase storage/messages and notify n8n via signed URLs before rendering responses
- add shared helpers for audio uploads and webhook JSON delivery

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7de0c0c7483249234624829ea3e71