### PR TITLE
Store Supabase conversation IDs in chat state

### DIFF
--- a/src/data/sampleChats.ts
+++ b/src/data/sampleChats.ts
@@ -18,6 +18,7 @@ export type ChatMessage = {
 
 export type Chat = {
   id: string;
+  conversationId: string | null;
   name: string;
   folder?: string;
   folderId?: string;

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -283,6 +283,7 @@ export const mapConversationToChat = (
 
   return {
     id: record.agent_id,
+    conversationId: record.id,
     name: record.agent_name ?? fallbackName,
     lastUpdated: formatDisplayTime(record.last_message_at ?? record.updated_at ?? record.created_at),
     preview: toPreview(summarySource),


### PR DESCRIPTION
## Summary
- extend chat models and mappers to store the Supabase conversation record ID alongside the agent ID
- update chat loading and message flows to capture persisted conversation IDs and reuse them for state updates
- ensure audio uploads and webhook payloads use the stored conversation record ID

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e8f03482b883249691e45907f75217