### PR TITLE
Add SwiftUI iOS wrapper and setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Der AITI Explorer Agent ist eine moderne React-Anwendung, mit der Teams ihre KI-
 - [Installation & lokale Entwicklung](#installation--lokale-entwicklung)
 - [Webhook-Anbindung](#webhook-anbindung)
 - [Lokale Speicherung & Branding](#lokale-speicherung--branding)
+- [iOS-Integration](#ios-integration)
 
 ## Überblick
 Die App stellt drei geschützte Bereiche (Chat, Einstellungen, Profil) sowie eine Login- und Registrierungsstrecke bereit und erzwingt die Anmeldung über einen zentralen Auth-Guard.【F:src/App.tsx†L1-L18】 Die Oberflächen wurden vollständig auf Deutsch gestaltet, um Agentenarbeit in deutschsprachigen Teams zu unterstützen.
@@ -74,3 +75,6 @@ Chatnachrichten werden zusammen mit Dateianhängen, Audioaufnahmen und Chatverla
 
 ## Lokale Speicherung & Branding
 Persönliche Einstellungen wie Profilname, Agenten-Branding, Farbschema, sowie lokal erstellte Chats und Ordner werden im Browser `localStorage` abgelegt. Bilder werden bei Bedarf komprimiert, um Speicher zu sparen. Änderungen lösen Events aus, die sowohl Profil- als auch Einstellungsseiten synchron halten.【F:src/utils/storage.ts†L1-L170】【F:src/pages/SettingsPage.tsx†L98-L389】【F:src/pages/ProfilePage.tsx†L82-L311】 Dadurch bleiben individuelle Anpassungen auch ohne Backend-Verbindung verfügbar.
+
+## iOS-Integration
+Eine native SwiftUI-Shell, die den gebauten Web-Client über `WKWebView` rendert, findest du im Ordner `ios/`. Die Datei [`ios/SETUP_GUIDE_DE.md`](ios/SETUP_GUIDE_DE.md) beschreibt Schritt für Schritt, wie der Vite-Build (`npm run build`) nach `ios/AITIExplorerAgent/WebAssets` kopiert, in Xcode eingebunden und anschließend im Simulator oder auf einem Gerät getestet wird. Die Swift-Dateien unter `ios/AITIExplorerAgent/App` liefern dafür das Grundgerüst und zeigen den Build-Status direkt in der App an.

--- a/ios/AITIExplorerAgent/.gitignore
+++ b/ios/AITIExplorerAgent/.gitignore
@@ -1,0 +1,2 @@
+# Web-Build wird lokal erzeugt und ins Bundle kopiert
+WebAssets/

--- a/ios/AITIExplorerAgent/App/AITIExplorerAgentApp.swift
+++ b/ios/AITIExplorerAgent/App/AITIExplorerAgentApp.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+@main
+struct AITIExplorerAgentApp: App {
+    @StateObject private var webAppModel = WebAppModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ZStack {
+                if let localIndexURL = webAppModel.indexURL {
+                    WebAppView(indexURL: localIndexURL)
+                        .ignoresSafeArea()
+                } else {
+                    MissingBundleView(state: webAppModel.state) {
+                        webAppModel.refresh()
+                    }
+                    .task {
+                        webAppModel.refresh()
+                    }
+                }
+            }
+            .background(Color(.systemBackground))
+        }
+    }
+}

--- a/ios/AITIExplorerAgent/App/MissingBundleView.swift
+++ b/ios/AITIExplorerAgent/App/MissingBundleView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct MissingBundleView: View {
+    let state: WebAppModel.State
+    let retry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 56, weight: .regular))
+                .foregroundColor(.orange)
+
+            Text(title)
+                .font(.title2)
+                .multilineTextAlignment(.center)
+
+            Text(message)
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            if shouldShowRetryButton {
+                Button(action: retry) {
+                    Label("Erneut prüfen", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+    }
+
+    private var title: String {
+        switch state {
+        case .loading:
+            return "Bundledaten werden gesucht"
+        case .missingAssets:
+            return "WebAssets fehlen"
+        case .failed:
+            return "Fehler beim Laden"
+        default:
+            return "Inhalt wird geladen"
+        }
+    }
+
+    private var message: String {
+        switch state {
+        case .loading:
+            return "Die App sucht nach dem im Bundle gespeicherten Web-Build."
+        case .missingAssets:
+            return "Bitte stelle sicher, dass der dist-Ordner nach ios/AITIExplorerAgent/WebAssets kopiert und im Copy Bundle Resources Build-Step enthalten ist."
+        case .failed(let description):
+            return description
+        case .idle:
+            return "Tippe auf \"Erneut prüfen\", nachdem der Web-Build hinzugefügt wurde."
+        case .ready:
+            return ""
+        }
+    }
+
+    private var shouldShowRetryButton: Bool {
+        switch state {
+        case .ready:
+            return false
+        default:
+            return true
+        }
+    }
+}
+
+struct MissingBundleView_Previews: PreviewProvider {
+    static var previews: some View {
+        MissingBundleView(state: .missingAssets, retry: {})
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/ios/AITIExplorerAgent/App/WebAppModel.swift
+++ b/ios/AITIExplorerAgent/App/WebAppModel.swift
@@ -1,0 +1,36 @@
+import Foundation
+import os.log
+
+@MainActor
+final class WebAppModel: ObservableObject {
+    enum State: Equatable {
+        case idle
+        case loading
+        case ready
+        case missingAssets
+        case failed(String)
+    }
+
+    @Published private(set) var state: State = .idle
+    @Published private(set) var indexURL: URL?
+
+    private let logger = Logger(subsystem: "com.aiti.explorer", category: "WebAppModel")
+
+    func refresh() {
+        guard state != .loading else { return }
+        state = .loading
+
+        do {
+            let indexURL = try WebAppURLResolver.locateIndexHTML()
+            self.indexURL = indexURL
+            state = .ready
+        } catch WebAppURLResolver.Error.indexFileMissing {
+            state = .missingAssets
+            indexURL = nil
+        } catch {
+            state = .failed(error.localizedDescription)
+            indexURL = nil
+            logger.error("Web bundle lookup failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/ios/AITIExplorerAgent/App/WebAppURLResolver.swift
+++ b/ios/AITIExplorerAgent/App/WebAppURLResolver.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum WebAppURLResolver {
+    enum Error: LocalizedError {
+        case indexFileMissing
+        case bundleResourceMissing
+
+        var errorDescription: String? {
+            switch self {
+            case .indexFileMissing:
+                return "Die Datei index.html konnte im WebAssets-Ordner nicht gefunden werden."
+            case .bundleResourceMissing:
+                return "Der WebAssets-Ordner ist nicht Bestandteil des App-Bundles."
+            }
+        }
+    }
+
+    static func locateIndexHTML(bundle: Bundle = .main) throws -> URL {
+        guard let webAssetsURL = bundle.url(forResource: "WebAssets", withExtension: nil) else {
+            throw Error.bundleResourceMissing
+        }
+
+        let indexURL = webAssetsURL.appendingPathComponent("index.html", isDirectory: false)
+        guard FileManager.default.fileExists(atPath: indexURL.path) else {
+            throw Error.indexFileMissing
+        }
+
+        return indexURL
+    }
+}

--- a/ios/AITIExplorerAgent/App/WebAppView.swift
+++ b/ios/AITIExplorerAgent/App/WebAppView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import WebKit
+
+struct WebAppView: UIViewRepresentable {
+    let indexURL: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.allowsInlineMediaPlayback = true
+        configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        webView.backgroundColor = .systemBackground
+        webView.scrollView.backgroundColor = .systemBackground
+
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
+
+        loadIndex(in: webView)
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        guard context.coordinator.requestedReload else { return }
+        loadIndex(in: uiView)
+        context.coordinator.requestedReload = false
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    private func loadIndex(in webView: WKWebView) {
+        let baseURL = indexURL.deletingLastPathComponent()
+        webView.loadFileURL(indexURL, allowingReadAccessTo: baseURL)
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        var requestedReload = false
+        private let parent: WebAppView
+
+        init(parent: WebAppView) {
+            self.parent = parent
+        }
+
+        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+            requestedReload = true
+            parent.loadIndex(in: webView)
+        }
+    }
+}

--- a/ios/SETUP_GUIDE_DE.md
+++ b/ios/SETUP_GUIDE_DE.md
@@ -1,0 +1,93 @@
+# iOS-Integration der AITI Explorer Web-App
+
+Diese Anleitung erklärt Schritt für Schritt, wie du die bestehende React-Anwendung in ein natives iOS-Projekt auf Basis von SwiftUI einbindest. Ziel ist, den mit Vite erzeugten Web-Build als gebundelte Ressourcen in einer iOS-App mit `WKWebView` bereitzustellen.
+
+## 1. Voraussetzungen
+
+- Xcode 15 oder neuer
+- Node.js 18+ und npm
+- Optional: Ein echter iOS-Gerät oder der iOS-Simulator
+
+## 2. Web-App bauen
+
+1. Im Projektstamm die Abhängigkeiten installieren (falls noch nicht geschehen):
+   ```bash
+   npm install
+   ```
+2. Produktions-Build erstellen:
+   ```bash
+   npm run build
+   ```
+   Der fertige Web-Build liegt danach im Ordner `dist/`.
+
+## 3. Web-Build für iOS vorbereiten
+
+1. Lege (falls noch nicht vorhanden) den Ordner `ios/AITIExplorerAgent/WebAssets` an.
+2. Kopiere den Inhalt des `dist/`-Ordners in `ios/AITIExplorerAgent/WebAssets`.
+   ```bash
+   rm -rf ios/AITIExplorerAgent/WebAssets
+   mkdir -p ios/AITIExplorerAgent/WebAssets
+   cp -R dist/* ios/AITIExplorerAgent/WebAssets/
+   ```
+3. Prüfe, dass sich innerhalb von `WebAssets` eine `index.html` und alle referenzierten Assets (JS, CSS, Fonts, Medien) befinden. Die Swift-App lädt exakt diese Struktur.
+
+> Tipp: Wiederhole Schritt 2 und 3 immer dann, wenn du Änderungen an der React-App vorgenommen hast. Automatisieren lässt sich das z. B. mit einem npm-Skript oder einem kleinen Shell-Skript.
+
+## 4. Neues Xcode-Projekt anlegen
+
+1. Starte Xcode und wähle **File → New → Project…**
+2. Template **App** unter **iOS** wählen und auf **Next** klicken.
+3. Produktname z. B. „AITIExplorerAgent“ eingeben, Team und Bundle Identifier festlegen.
+4. Programmiersprache **Swift**, Interface **SwiftUI**, Lifecycle **SwiftUI App**.
+5. Projekt speichern (z. B. im Ordner `ios/AITIExplorerAgent` neben den bereitgestellten Swift-Dateien).
+
+## 5. Swift-Dateien übernehmen
+
+Im Ordner `ios/AITIExplorerAgent/App` liegen vorbereitete Swift-Dateien. Ziehe die folgenden Dateien per Drag & Drop (oder via **File → Add Files…**) in dein Xcode-Projekt und achte darauf, dass **Copy items if needed** aktiviert ist und der Target-Haken gesetzt ist:
+
+- `AITIExplorerAgentApp.swift`
+- `WebAppModel.swift`
+- `WebAppURLResolver.swift`
+- `WebAppView.swift`
+- `MissingBundleView.swift`
+
+Diese Dateien ersetzen den Standard-Inhalt des automatisch generierten SwiftUI-Projektes.
+
+## 6. WebAssets ins App-Bundle einbinden
+
+1. Ziehe den kompletten Ordner `ios/AITIExplorerAgent/WebAssets` in das Xcode-Projekt (z. B. in eine Gruppe namens „Resources“).
+2. Aktiviere beim Import die Optionen **Create folder references** und **Copy items if needed**. Die Ordner-Referenz stellt sicher, dass die Ordnerstruktur 1:1 im Bundle landet.
+3. In den **Build Phases** deines Targets kontrollieren, dass `WebAssets` unter **Copy Bundle Resources** auftaucht.
+
+## 7. App starten
+
+1. Wähle im Xcode-Scheme den gewünschten Simulator oder ein verbundenes iOS-Gerät.
+2. Starte die App mit `Cmd + R`.
+3. Beim ersten Start sucht die App nach `WebAssets/index.html`. Falls der Ordner fehlt, zeigt sie eine Hinweisseite mit einem Button „Erneut prüfen“. Nach dem Kopieren der Assets genügt ein erneuter Start oder ein Tippen auf den Button.
+
+## 8. Optional: Live-Reload während der Entwicklung
+
+- Während der lokalen Web-Entwicklung kannst du anstelle des gebauten Bundles auch den Vite-Dev-Server verwenden, indem du den `WKWebView` auf `http://<deine-ip>:5173` zeigst. Passe dafür in `AITIExplorerAgentApp.swift` und `WebAppView.swift` den Ladevorgang an (z. B. durch eine Debug-Flag, die `load(URLRequest(url:))` anstößt).
+- Achte darauf, das Laden unsicherer (http) Inhalte auf echten Geräten über App-Transport-Security anzupassen (`Info.plist`).
+
+## 9. Aktualisierung für App Store Builds
+
+- Vor jedem Release `npm run build` ausführen und den `dist/`-Inhalt nach `WebAssets` kopieren.
+- Danach das Projekt archivieren (`Product → Archive`) und wie gewohnt signieren.
+
+## 10. Häufige Fehlerquellen
+
+| Problem | Ursache | Lösung |
+| --- | --- | --- |
+| Startbildschirm bleibt leer | `WebAssets` fehlen im Bundle | Ordner als Folder Reference ins Projekt ziehen und Build erneut ausführen |
+| Konsole meldet „index.html nicht gefunden“ | Build nicht nach `WebAssets` kopiert | Schritt 3 wiederholen |
+| Keine Styles / Broken Layout | Nicht alle Dateien aus `dist/` kopiert | Ordner komplett löschen und frisch kopieren |
+| Audio-Aufnahme funktioniert nicht | `WKWebView` benötigt Mikrofon-Berechtigung | In `Info.plist` den Schlüssel `NSMicrophoneUsageDescription` ergänzen |
+
+## 11. Weiterführende Anpassungen
+
+- Über `WKUserContentController` lassen sich native und webbasierte Funktionen koppeln (z. B. Push-Notifications, Dateiauswahl).
+- Für Offline-Fähigkeit kann der Web-Build um Service Worker erweitert werden.
+- Swift-spezifische Funktionen (z. B. Kamera) kannst du über `WKScriptMessageHandler` mit dem bestehenden JavaScript verknüpfen.
+
+Damit steht einer lauffähigen iOS-App nichts mehr im Wege. Viel Erfolg beim Testen und Deployen!


### PR DESCRIPTION
## Summary
- add a SwiftUI-based shell application that renders the built web client via WKWebView
- provide a German setup guide detailing how to package the Vite build inside an iOS project
- document the new iOS integration workflow in the main README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68efbef850d08324ba82aa846ff5390e