### PR TITLE
Add SwiftUI iOS port and setup instructions

### DIFF
--- a/ios/AITIExplorer/AITIExplorerApp.swift
+++ b/ios/AITIExplorer/AITIExplorerApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct AITIExplorerApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(appState)
+        }
+    }
+}

--- a/ios/AITIExplorer/Models/AgentSettingsModel.swift
+++ b/ios/AITIExplorer/Models/AgentSettingsModel.swift
@@ -1,0 +1,87 @@
+import Foundation
+import SwiftUI
+
+enum ColorSchemeOption: String, CaseIterable, Identifiable, Codable {
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .system:
+            return "System"
+        case .light:
+            return "Hell"
+        case .dark:
+            return "Dunkel"
+        }
+    }
+
+    var preferredScheme: ColorScheme? {
+        switch self {
+        case .system:
+            return nil
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        }
+    }
+}
+
+enum AccentColorOption: String, CaseIterable, Identifiable, Codable {
+    case gold
+    case emerald
+    case indigo
+    case orange
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .gold:
+            return "Gold"
+        case .emerald:
+            return "Smaragd"
+        case .indigo:
+            return "Indigo"
+        case .orange:
+            return "Orange"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .gold:
+            return Color(red: 0.95, green: 0.79, blue: 0.36)
+        case .emerald:
+            return Color(red: 0.19, green: 0.69, blue: 0.49)
+        case .indigo:
+            return Color(red: 0.35, green: 0.4, blue: 0.94)
+        case .orange:
+            return Color(red: 0.99, green: 0.57, blue: 0.23)
+        }
+    }
+}
+
+struct AgentSettingsModel: Codable, Hashable {
+    var colorScheme: ColorSchemeOption
+    var accentColor: AccentColorOption
+    var playSendSound: Bool
+    var showTypingIndicator: Bool
+    var preferCompactLayout: Bool
+    var webhookURL: URL?
+    var notes: String
+
+    static let `default` = AgentSettingsModel(
+        colorScheme: .system,
+        accentColor: .gold,
+        playSendSound: true,
+        showTypingIndicator: true,
+        preferCompactLayout: false,
+        webhookURL: nil,
+        notes: ""
+    )
+}

--- a/ios/AITIExplorer/Models/ChatAttachment.swift
+++ b/ios/AITIExplorer/Models/ChatAttachment.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+enum AttachmentKind: String, Codable, CaseIterable, Identifiable {
+    case file
+    case audio
+
+    var id: String { rawValue }
+
+    var iconName: String {
+        switch self {
+        case .file:
+            return "doc.fill"
+        case .audio:
+            return "waveform.circle.fill"
+        }
+    }
+}
+
+struct ChatAttachment: Identifiable, Codable, Hashable {
+    let id: UUID
+    var name: String
+    var size: Int
+    var type: String
+    var url: URL?
+    var kind: AttachmentKind
+    var durationSeconds: Int?
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        size: Int,
+        type: String,
+        url: URL? = nil,
+        kind: AttachmentKind,
+        durationSeconds: Int? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.size = size
+        self.type = type
+        self.url = url
+        self.kind = kind
+        self.durationSeconds = durationSeconds
+    }
+
+    var formattedSize: String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: Int64(size))
+    }
+}

--- a/ios/AITIExplorer/Models/ChatMessage.swift
+++ b/ios/AITIExplorer/Models/ChatMessage.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+enum MessageAuthor: String, Codable, CaseIterable, Identifiable {
+    case agent
+    case user
+
+    var id: String { rawValue }
+}
+
+struct ChatMessage: Identifiable, Codable, Hashable {
+    let id: UUID
+    var author: MessageAuthor
+    var content: String
+    var timestamp: Date
+    var attachments: [ChatAttachment]
+
+    init(
+        id: UUID = UUID(),
+        author: MessageAuthor,
+        content: String,
+        timestamp: Date = Date(),
+        attachments: [ChatAttachment] = []
+    ) {
+        self.id = id
+        self.author = author
+        self.content = content
+        self.timestamp = timestamp
+        self.attachments = attachments
+    }
+}
+
+extension ChatMessage {
+    var timeLabel: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter.string(from: timestamp)
+    }
+}

--- a/ios/AITIExplorer/Models/Conversation.swift
+++ b/ios/AITIExplorer/Models/Conversation.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+enum AgentStatus: String, Codable, CaseIterable, Identifiable {
+    case online
+    case offline
+    case busy
+
+    var id: String { rawValue }
+
+    var description: String {
+        switch self {
+        case .online:
+            return "Verfügbar"
+        case .offline:
+            return "Offline"
+        case .busy:
+            return "Beschäftigt"
+        }
+    }
+}
+
+struct Conversation: Identifiable, Codable, Hashable {
+    let id: UUID
+    var agentId: UUID
+    var title: String
+    var lastUpdated: Date
+    var messages: [ChatMessage]
+
+    init(
+        id: UUID = UUID(),
+        agentId: UUID,
+        title: String,
+        lastUpdated: Date = Date(),
+        messages: [ChatMessage] = []
+    ) {
+        self.id = id
+        self.agentId = agentId
+        self.title = title
+        self.lastUpdated = lastUpdated
+        self.messages = messages
+    }
+
+    var preview: String {
+        messages.last?.content ?? "Beschreibe dein nächstes Projekt und starte den AI Agent."
+    }
+
+    mutating func append(_ message: ChatMessage) {
+        messages.append(message)
+        lastUpdated = message.timestamp
+    }
+}
+
+struct AgentProfile: Identifiable, Codable, Hashable {
+    var id: UUID
+    var name: String
+    var role: String
+    var description: String
+    var status: AgentStatus
+    var avatarSystemName: String
+    var conversation: Conversation
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        role: String,
+        description: String,
+        status: AgentStatus = .online,
+        avatarSystemName: String = "bolt.fill",
+        conversation: Conversation
+    ) {
+        self.id = id
+        self.name = name
+        self.role = role
+        self.description = description
+        self.status = status
+        self.avatarSystemName = avatarSystemName
+        self.conversation = conversation
+    }
+}

--- a/ios/AITIExplorer/Models/UserProfile.swift
+++ b/ios/AITIExplorer/Models/UserProfile.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct UserProfile: Identifiable, Codable, Hashable {
+    var id: UUID
+    var name: String
+    var email: String
+    var bio: String
+    var avatarSystemName: String
+    var isActive: Bool
+    var agents: [AgentProfile]
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        email: String,
+        bio: String = "",
+        avatarSystemName: String = "person.crop.circle.fill",
+        isActive: Bool = true,
+        agents: [AgentProfile] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.email = email
+        self.bio = bio
+        self.avatarSystemName = avatarSystemName
+        self.isActive = isActive
+        self.agents = agents
+    }
+}

--- a/ios/AITIExplorer/Resources/SampleData.swift
+++ b/ios/AITIExplorer/Resources/SampleData.swift
@@ -1,0 +1,139 @@
+import Foundation
+import SwiftUI
+
+enum SampleData {
+    static let projectAttachment = ChatAttachment(
+        name: "Projektplan.pdf",
+        size: 1_024_000,
+        type: "application/pdf",
+        kind: .file
+    )
+
+    static let audioAttachment = ChatAttachment(
+        name: "Feedback.m4a",
+        size: 420_000,
+        type: "audio/m4a",
+        kind: .audio,
+        durationSeconds: 42
+    )
+
+    static let welcomeMessage = ChatMessage(
+        author: .agent,
+        content: "Hallo! Ich bin dein AITI Explorer Agent. Wie kann ich dir heute helfen?",
+        timestamp: Date().addingTimeInterval(-3600),
+        attachments: []
+    )
+
+    static let followUpMessage = ChatMessage(
+        author: .user,
+        content: "Ich brauche Unterstützung bei der Planung einer Launch-Kampagne.",
+        timestamp: Date().addingTimeInterval(-3400),
+        attachments: [projectAttachment]
+    )
+
+    static let agentResponse = ChatMessage(
+        author: .agent,
+        content: "Sehr gern! Ich schlage vor, dass wir mit einer Zielgruppenanalyse starten. Soll ich dir dafür ein Template vorbereiten?",
+        timestamp: Date().addingTimeInterval(-3200),
+        attachments: []
+    )
+
+    static func conversation(agentId: UUID, title: String) -> Conversation {
+        Conversation(
+            agentId: agentId,
+            title: title,
+            lastUpdated: Date(),
+            messages: [welcomeMessage, followUpMessage, agentResponse]
+        )
+    }
+
+    static var marketingAgent: AgentProfile {
+        let id = UUID()
+        return AgentProfile(
+            id: id,
+            name: "Explorer Marketing",
+            role: "Kampagnen-Spezialist",
+            description: "Unterstützt dich bei der Planung deiner Marketing-Aktivitäten.",
+            status: .online,
+            avatarSystemName: "megaphone.fill",
+            conversation: conversation(agentId: id, title: "Launch Kampagne")
+        )
+    }
+
+    static var productAgent: AgentProfile {
+        let id = UUID()
+        return AgentProfile(
+            id: id,
+            name: "Explorer Produkt",
+            role: "Produktmanager",
+            description: "Analysiert Anforderungen und erstellt User Stories.",
+            status: .busy,
+            avatarSystemName: "shippingbox.fill",
+            conversation: conversation(agentId: id, title: "Feature Discovery")
+        )
+    }
+
+    static var researchAgent: AgentProfile {
+        let id = UUID()
+        return AgentProfile(
+            id: id,
+            name: "Explorer Research",
+            role: "Research Analyst",
+            description: "Findet Antworten und fasst Ergebnisse prägnant zusammen.",
+            status: .offline,
+            avatarSystemName: "chart.bar.fill",
+            conversation: conversation(agentId: id, title: "Marktanalyse")
+        )
+    }
+
+    static var previewUser: UserProfile {
+        UserProfile(
+            name: "Alex Example",
+            email: "demo@aiti.ai",
+            bio: "Leitet AI-gestützte Innovationsprojekte im Team.",
+            avatarSystemName: "person.crop.circle.fill.badge.checkmark",
+            isActive: true,
+            agents: [marketingAgent, productAgent, researchAgent]
+        )
+    }
+
+    static var demoCredentials: UserCredentials {
+        UserCredentials(
+            email: "demo@aiti.ai",
+            password: "SwiftRocks!",
+            profile: previewUser
+        )
+    }
+
+    static var defaultSettings: AgentSettingsModel {
+        if let stored = loadSettings() {
+            return stored
+        }
+        return AgentSettingsModel(
+            colorScheme: .system,
+            accentColor: .gold,
+            playSendSound: true,
+            showTypingIndicator: true,
+            preferCompactLayout: false,
+            webhookURL: URL(string: "https://hooks.aiti.ai/example"),
+            notes: "Verbinde deinen Agent mit deinen internen Tools über Webhooks."
+        )
+    }
+
+    private static let settingsKey = "aiti.settings"
+
+    private static func loadSettings() -> AgentSettingsModel? {
+        guard let data = UserDefaults.standard.data(forKey: settingsKey) else {
+            return nil
+        }
+
+        return try? JSONDecoder().decode(AgentSettingsModel.self, from: data)
+    }
+
+    static func saveSettings(_ settings: AgentSettingsModel) {
+        let encoder = JSONEncoder()
+        if let data = try? encoder.encode(settings) {
+            UserDefaults.standard.set(data, forKey: settingsKey)
+        }
+    }
+}

--- a/ios/AITIExplorer/ViewModels/AppState.swift
+++ b/ios/AITIExplorer/ViewModels/AppState.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Combine
+import SwiftUI
+
+final class AppState: ObservableObject {
+    enum Tab: Hashable {
+        case chat
+        case settings
+        case profile
+    }
+
+    @Published var currentUser: UserProfile?
+    @Published var settings: AgentSettingsModel
+    @Published var selectedTab: Tab = .chat
+
+    private(set) var registeredUsers: [UserCredentials]
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init(previewUser: UserProfile? = nil) {
+        let defaults = SampleData.defaultSettings
+        self.settings = defaults
+        self.registeredUsers = [SampleData.demoCredentials]
+        self.currentUser = previewUser
+
+        $settings
+            .dropFirst()
+            .sink { newSettings in
+                SampleData.saveSettings(newSettings)
+            }
+            .store(in: &cancellables)
+    }
+
+    func login(email: String, password: String) throws {
+        guard let credentials = registeredUsers.first(where: { $0.email.lowercased() == email.lowercased() }) else {
+            throw AuthError.accountNotFound
+        }
+
+        guard credentials.password == password else {
+            throw AuthError.invalidPassword
+        }
+
+        currentUser = credentials.profile
+        selectedTab = .chat
+    }
+
+    func register(name: String, email: String, password: String) throws {
+        guard !registeredUsers.contains(where: { $0.email.lowercased() == email.lowercased() }) else {
+            throw AuthError.emailAlreadyRegistered
+        }
+
+        var newProfile = SampleData.previewUser
+        newProfile.id = UUID()
+        newProfile.name = name
+        newProfile.email = email
+
+        let credentials = UserCredentials(email: email, password: password, profile: newProfile)
+        registeredUsers.append(credentials)
+        currentUser = newProfile
+        selectedTab = .profile
+    }
+
+    func logout() {
+        currentUser = nil
+        selectedTab = .chat
+    }
+
+    func updateCurrentUser(_ profile: UserProfile) {
+        currentUser = profile
+        if let index = registeredUsers.firstIndex(where: { $0.email.lowercased() == profile.email.lowercased() }) {
+            registeredUsers[index].profile = profile
+        }
+    }
+
+    func updateSettings(_ settings: AgentSettingsModel) {
+        self.settings = settings
+    }
+
+    enum AuthError: LocalizedError {
+        case accountNotFound
+        case invalidPassword
+        case emailAlreadyRegistered
+
+        var errorDescription: String? {
+            switch self {
+            case .accountNotFound:
+                return "Für diese E-Mail existiert noch kein Account."
+            case .invalidPassword:
+                return "Das Passwort ist nicht korrekt."
+            case .emailAlreadyRegistered:
+                return "Diese E-Mail ist bereits registriert."
+            }
+        }
+    }
+}
+
+struct UserCredentials: Identifiable, Hashable {
+    var id = UUID()
+    let email: String
+    var password: String
+    var profile: UserProfile
+}

--- a/ios/AITIExplorer/ViewModels/AuthViewModel.swift
+++ b/ios/AITIExplorer/ViewModels/AuthViewModel.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Combine
+
+final class AuthViewModel: ObservableObject {
+    enum Mode: Hashable {
+        case login
+        case register
+    }
+
+    @Published var mode: Mode = .login
+    @Published var name: String = ""
+    @Published var email: String = ""
+    @Published var password: String = ""
+    @Published var confirmPassword: String = ""
+    @Published var isProcessing = false
+    @Published var errorMessage: String?
+    @Published var infoMessage: String?
+
+    private var appState: AppState?
+
+    init(appState: AppState? = nil) {
+        self.appState = appState
+    }
+
+    func attach(appState: AppState) {
+        self.appState = appState
+    }
+
+    var primaryButtonTitle: String {
+        mode == .login ? "Anmelden" : "Account erstellen"
+    }
+
+    var secondaryButtonTitle: String {
+        mode == .login ? "Account anlegen" : "Ich habe bereits einen Account"
+    }
+
+    func toggleMode() {
+        mode = mode == .login ? .register : .login
+        errorMessage = nil
+        infoMessage = nil
+    }
+
+    func submit() {
+        isProcessing = true
+        errorMessage = nil
+        infoMessage = nil
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
+
+            do {
+                switch self.mode {
+                case .login:
+                    guard let appState = self.appState else { throw AuthLifecycleError.missingAppState }
+                    try appState.login(email: self.email, password: self.password)
+                    DispatchQueue.main.async {
+                        self.infoMessage = "Erfolgreich angemeldet. Willkommen zurück!"
+                    }
+                case .register:
+                    guard self.password == self.confirmPassword else {
+                        throw RegistrationError.passwordMismatch
+                    }
+                    guard let appState = self.appState else { throw AuthLifecycleError.missingAppState }
+                    try appState.register(name: self.name, email: self.email, password: self.password)
+                    DispatchQueue.main.async {
+                        self.infoMessage = "Account erstellt! Du kannst dein Profil nun anpassen."
+                    }
+                }
+            } catch let error as RegistrationError {
+                DispatchQueue.main.async {
+                    self.errorMessage = error.localizedDescription
+                }
+            } catch let error as AppState.AuthError {
+                DispatchQueue.main.async {
+                    self.errorMessage = error.localizedDescription
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.errorMessage = "Es ist ein unbekannter Fehler aufgetreten."
+                }
+            }
+
+            DispatchQueue.main.async {
+                self.isProcessing = false
+            }
+        }
+    }
+
+    enum RegistrationError: LocalizedError {
+        case passwordMismatch
+
+        var errorDescription: String? {
+            switch self {
+            case .passwordMismatch:
+                return "Die Passwörter stimmen nicht überein."
+            }
+        }
+    }
+
+    enum AuthLifecycleError: LocalizedError {
+        case missingAppState
+
+        var errorDescription: String? {
+            "Der Applikationsstatus konnte nicht initialisiert werden."
+        }
+    }
+}

--- a/ios/AITIExplorer/ViewModels/ChatViewModel.swift
+++ b/ios/AITIExplorer/ViewModels/ChatViewModel.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Combine
+
+final class ChatViewModel: ObservableObject {
+    @Published private(set) var agents: [AgentProfile] = []
+    @Published var selectedAgentID: UUID?
+    @Published var searchQuery: String = ""
+    @Published var searchResults: [ChatMessage] = []
+    @Published var isSearching = false
+    @Published var isShowingOverviewOnPhone = false
+    @Published var pendingResponse = false
+
+    private var appState: AppState?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(appState: AppState? = nil) {
+        self.appState = appState
+        configureBindings()
+    }
+
+    func attach(appState: AppState) {
+        self.appState = appState
+        configureBindings()
+        if selectedAgentID == nil, let agent = appState.currentUser?.agents.first {
+            selectedAgentID = agent.id
+        }
+    }
+
+    var selectedAgent: AgentProfile? {
+        agents.first(where: { $0.id == selectedAgentID })
+    }
+
+    func select(agent: AgentProfile) {
+        selectedAgentID = agent.id
+        isShowingOverviewOnPhone = false
+    }
+
+    func sendMessage(_ text: String) {
+        guard var agent = selectedAgent, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+
+        let userMessage = ChatMessage(author: .user, content: text)
+        agent.conversation.append(userMessage)
+        update(agent)
+
+        pendingResponse = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
+            guard let self else { return }
+            let reply = ChatMessage(
+                author: .agent,
+                content: "Danke für deine Nachricht! Ich kümmere mich darum und melde mich mit einem Vorschlag."
+            )
+            self.append(message: reply, to: agent)
+            self.pendingResponse = false
+        }
+    }
+
+    func deleteConversation(for agent: AgentProfile) {
+        guard let index = agents.firstIndex(where: { $0.id == agent.id }) else { return }
+        var updatedAgent = agent
+        updatedAgent.conversation.messages.removeAll()
+        updatedAgent.conversation.lastUpdated = Date()
+        update(updatedAgent)
+    }
+
+    private func append(message: ChatMessage, to agent: AgentProfile) {
+        var updatedAgent = agent
+        updatedAgent.conversation.append(message)
+        update(updatedAgent)
+    }
+
+    private func update(_ agent: AgentProfile) {
+        guard let appState = appState, var user = appState.currentUser else { return }
+        if let index = user.agents.firstIndex(where: { $0.id == agent.id }) {
+            user.agents[index] = agent
+            appState.updateCurrentUser(user)
+        }
+    }
+
+    private func performSearch(query: String) {
+        guard let agent = selectedAgent else {
+            searchResults = []
+            return
+        }
+
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            searchResults = []
+            isSearching = false
+            return
+        }
+
+        isSearching = true
+        let lowercased = trimmed.lowercased()
+        searchResults = agent.conversation.messages.filter { message in
+            message.content.lowercased().contains(lowercased)
+        }
+        isSearching = false
+    }
+}
+
+private extension ChatViewModel {
+    func configureBindings() {
+        cancellables.removeAll()
+
+        appState?.$currentUser
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] user in
+                guard let self else { return }
+                self.agents = user?.agents ?? []
+                if let first = self.agents.first, self.selectedAgentID == nil {
+                    self.selectedAgentID = first.id
+                }
+            }
+            .store(in: &cancellables)
+
+        $searchQuery
+            .debounce(for: .milliseconds(250), scheduler: DispatchQueue.main)
+            .removeDuplicates()
+            .sink { [weak self] query in
+                self?.performSearch(query: query)
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/ios/AITIExplorer/ViewModels/ProfileViewModel.swift
+++ b/ios/AITIExplorer/ViewModels/ProfileViewModel.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Combine
+
+final class ProfileViewModel: ObservableObject {
+    @Published var profile: UserProfile
+    @Published var draftName: String
+    @Published var draftBio: String
+    @Published var isActive: Bool
+    @Published var agents: [AgentProfile]
+    @Published var toastMessage: String?
+
+    private var appState: AppState?
+
+    init(appState: AppState? = nil) {
+        self.appState = appState
+        let profile = appState?.currentUser ?? SampleData.previewUser
+        self.profile = profile
+        self.draftName = profile.name
+        self.draftBio = profile.bio
+        self.isActive = profile.isActive
+        self.agents = profile.agents
+
+        configureBindings()
+    }
+
+    func attach(appState: AppState) {
+        self.appState = appState
+        configureBindings()
+        if let profile = appState.currentUser {
+            self.profile = profile
+            self.draftName = profile.name
+            self.draftBio = profile.bio
+            self.isActive = profile.isActive
+            self.agents = profile.agents
+        }
+    }
+
+    private var cancellables = Set<AnyCancellable>()
+
+    func saveProfile() {
+        profile.name = draftName
+        profile.bio = draftBio
+        profile.isActive = isActive
+        profile.agents = agents
+        appState?.updateCurrentUser(profile)
+        toastMessage = "Profil gespeichert"
+    }
+
+    func toggleAgent(_ agent: AgentProfile) {
+        guard let index = agents.firstIndex(where: { $0.id == agent.id }) else { return }
+        var updated = agent
+        updated.status = agent.status == .online ? .offline : .online
+        agents[index] = updated
+        saveProfile()
+    }
+
+    func addAgent(name: String, role: String) {
+        guard !name.isEmpty else { return }
+        let agentId = UUID()
+        let conversation = Conversation(agentId: agentId, title: "Neuer Chat")
+        let agent = AgentProfile(
+            id: agentId,
+            name: name,
+            role: role.isEmpty ? "Individueller Agent" : role,
+            description: "Neuer individueller Agent.",
+            conversation: conversation
+        )
+        agents.append(agent)
+        saveProfile()
+    }
+
+    func removeAgent(_ agent: AgentProfile) {
+        agents.removeAll { $0.id == agent.id }
+        saveProfile()
+    }
+}
+
+private extension ProfileViewModel {
+    func configureBindings() {
+        cancellables.removeAll()
+
+        appState?.$currentUser
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] profile in
+                self?.profile = profile
+                self?.draftName = profile.name
+                self?.draftBio = profile.bio
+                self?.isActive = profile.isActive
+                self?.agents = profile.agents
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/ios/AITIExplorer/ViewModels/SettingsViewModel.swift
+++ b/ios/AITIExplorer/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+final class SettingsViewModel: ObservableObject {
+    @Published var settings: AgentSettingsModel
+    @Published var saveStatus: SaveStatus = .idle
+    @Published var webhookTestStatus: SaveStatus = .idle
+    @Published var webhookMessage: String?
+
+    enum SaveStatus {
+        case idle
+        case success
+        case failure
+        case inProgress
+    }
+
+    private var appState: AppState?
+
+    init(appState: AppState? = nil) {
+        self.appState = appState
+        self.settings = appState?.settings ?? SampleData.defaultSettings
+    }
+
+    func attach(appState: AppState) {
+        self.appState = appState
+        self.settings = appState.settings
+    }
+
+    func save() {
+        saveStatus = .inProgress
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+            guard let self else { return }
+            self.appState?.updateSettings(self.settings)
+            self.saveStatus = .success
+        }
+    }
+
+    func reset() {
+        if let appState {
+            settings = appState.settings
+        }
+        saveStatus = .idle
+    }
+
+    func testWebhook() {
+        guard settings.webhookURL != nil else {
+            webhookMessage = "Bitte hinterlege zuerst eine gültige URL."
+            webhookTestStatus = .failure
+            return
+        }
+
+        webhookTestStatus = .inProgress
+        webhookMessage = "Webhook Test wird gesendet …"
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            self?.webhookMessage = "Webhook erfolgreich simuliert!"
+            self?.webhookTestStatus = .success
+        }
+    }
+}

--- a/ios/AITIExplorer/Views/AuthView.swift
+++ b/ios/AITIExplorer/Views/AuthView.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+
+struct AuthView: View {
+    @EnvironmentObject private var appState: AppState
+    @StateObject private var viewModel = AuthViewModel()
+
+    var body: some View {
+        VStack {
+            Spacer(minLength: 40)
+
+            VStack(spacing: 16) {
+                Image(systemName: "bolt.badge.a.fill")
+                    .font(.system(size: 56))
+                    .foregroundStyle(.linearGradient(colors: [Color.yellow, Color.orange], startPoint: .topLeading, endPoint: .bottomTrailing))
+
+                Text("AITI Explorer Agent")
+                    .font(.title)
+                    .fontWeight(.semibold)
+
+                Text("Verwalte deine AI Agents, Chats und Integrationen an einem Ort.")
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal)
+            }
+            .padding(.bottom, 24)
+
+            formSection
+                .padding()
+                .frame(maxWidth: 480)
+                .background(.thinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 24))
+                .shadow(color: .black.opacity(0.2), radius: 20, x: 0, y: 14)
+                .padding(.horizontal)
+
+            Spacer()
+            footer
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+        .background(LinearGradient(colors: [.black, Color(.sRGB, red: 0.1, green: 0.1, blue: 0.12, opacity: 1)], startPoint: .top, endPoint: .bottom))
+        .onReceive(appState.$currentUser) { user in
+            if user != nil {
+                viewModel.infoMessage = nil
+            }
+        }
+        .onAppear {
+            viewModel.attach(appState: appState)
+            viewModel.infoMessage = "Nutze demo@aiti.ai und SwiftRocks! zum Testen."
+        }
+    }
+
+    private var formSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Picker("Modus", selection: $viewModel.mode) {
+                Text("Anmelden").tag(AuthViewModel.Mode.login)
+                Text("Registrieren").tag(AuthViewModel.Mode.register)
+            }
+            .pickerStyle(.segmented)
+
+            if viewModel.mode == .register {
+                TextField("Name", text: $viewModel.name)
+                    .textContentType(.name)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            TextField("E-Mail", text: $viewModel.email)
+                .textContentType(.emailAddress)
+                .keyboardType(.emailAddress)
+                .textInputAutocapitalization(.never)
+                .textFieldStyle(.roundedBorder)
+
+            SecureField("Passwort", text: $viewModel.password)
+                .textContentType(.password)
+                .textFieldStyle(.roundedBorder)
+
+            if viewModel.mode == .register {
+                SecureField("Passwort bestätigen", text: $viewModel.confirmPassword)
+                    .textContentType(.password)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            Button(action: viewModel.submit) {
+                if viewModel.isProcessing {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .frame(maxWidth: .infinity)
+                } else {
+                    Text(viewModel.primaryButtonTitle)
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.isProcessing)
+
+            Button(viewModel.secondaryButtonTitle) {
+                withAnimation(.spring()) {
+                    viewModel.toggleMode()
+                }
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+
+            if let errorMessage = viewModel.errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+                    .font(.footnote)
+                    .frame(maxWidth: .infinity)
+            }
+
+            if let info = viewModel.infoMessage {
+                Label(info, systemImage: "info.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.footnote)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    private var footer: some View {
+        VStack(spacing: 8) {
+            Text("Demo-Zugang")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text("E-Mail: demo@aiti.ai • Passwort: SwiftRocks!")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.bottom, 8)
+    }
+}
+
+#Preview {
+    AuthView()
+        .environmentObject(AppState())
+}

--- a/ios/AITIExplorer/Views/ChatContainerView.swift
+++ b/ios/AITIExplorer/Views/ChatContainerView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+struct ChatContainerView: View {
+    @EnvironmentObject private var appState: AppState
+    @StateObject private var viewModel = ChatViewModel()
+    @State private var draftedMessage: String = ""
+    @State private var showSearchSheet = false
+
+    var body: some View {
+        NavigationSplitView(columnVisibility: .constant(.automatic)) {
+            chatList
+        } detail: {
+            if let agent = viewModel.selectedAgent {
+                ChatDetailView(
+                    agent: agent,
+                    draftedMessage: $draftedMessage,
+                    onSend: { text in
+                        viewModel.sendMessage(text)
+                        draftedMessage = ""
+                    },
+                    pendingResponse: viewModel.pendingResponse,
+                    onShowSearch: {
+                        showSearchSheet.toggle()
+                        viewModel.isSearching = true
+                    }
+                )
+                .toolbar { toolbarItems }
+                .navigationTitle(agent.name)
+            } else {
+                ContentUnavailableView(
+                    "Kein Agent ausgewählt",
+                    systemImage: "message.badge.waveform.fill",
+                    description: Text("Lege in deinem Profil einen Agenten an oder aktiviere ihn." )
+                )
+            }
+        }
+        .navigationSplitViewStyle(.balanced)
+        .onAppear {
+            viewModel.attach(appState: appState)
+            if viewModel.selectedAgent == nil, let agent = appState.currentUser?.agents.first {
+                viewModel.select(agent: agent)
+            }
+            viewModel.isShowingOverviewOnPhone = false
+        }
+        .sheet(isPresented: $showSearchSheet) {
+            NavigationStack {
+                SearchResultsView(
+                    query: $viewModel.searchQuery,
+                    results: viewModel.searchResults,
+                    isSearching: viewModel.isSearching
+                )
+            }
+            .presentationDetents([.medium, .large])
+        }
+        .onAppear {
+            viewModel.isSearching = false
+        }
+    }
+
+    private var chatList: some View {
+        List(selection: $viewModel.selectedAgentID) {
+            Section("Deine Agents") {
+                ForEach(viewModel.agents) { agent in
+                    ChatListRow(agent: agent)
+                        .tag(agent.id)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            viewModel.select(agent: agent)
+                        }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Chats")
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarItems: some ToolbarContent {
+        ToolbarItemGroup(placement: .navigationBarTrailing) {
+            Button {
+                showSearchSheet.toggle()
+            } label: {
+                Image(systemName: "magnifyingglass")
+            }
+            .accessibilityLabel("Chats durchsuchen")
+        }
+    }
+}
+
+private struct ChatListRow: View {
+    let agent: AgentProfile
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(.ultraThinMaterial)
+                    .frame(width: 44, height: 44)
+                Image(systemName: agent.avatarSystemName)
+                    .font(.title3)
+                    .foregroundStyle(.white)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(agent.name)
+                    .font(.headline)
+                Text(agent.conversation.preview)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(agent.conversation.lastUpdated, style: .time)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Label(agent.status.description, systemImage: statusIcon)
+                    .font(.caption2)
+                    .labelStyle(.titleAndIcon)
+                    .foregroundStyle(statusColor)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+
+    private var statusIcon: String {
+        switch agent.status {
+        case .online:
+            return "circle.fill"
+        case .offline:
+            return "circle"
+        case .busy:
+            return "clock"
+        }
+    }
+
+    private var statusColor: Color {
+        switch agent.status {
+        case .online:
+            return .green
+        case .offline:
+            return .gray
+        case .busy:
+            return .orange
+        }
+    }
+}
+
+#Preview {
+    ChatContainerView()
+        .environmentObject(AppState(previewUser: SampleData.previewUser))
+}

--- a/ios/AITIExplorer/Views/ChatDetailView.swift
+++ b/ios/AITIExplorer/Views/ChatDetailView.swift
@@ -130,7 +130,7 @@ private struct ChatBubble: View {
             VStack(alignment: message.author == .agent ? .leading : .trailing, spacing: 10) {
                 Text(message.content)
                     .padding(16)
-                    .foregroundStyle(message.author == .agent ? .primary : .white)
+                    .foregroundStyle(message.author == .agent ? .primary : Color.white)
                     .background(bubbleBackground)
                     .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
 
@@ -246,7 +246,7 @@ private struct MessageComposer: View {
             } label: {
                 Image(systemName: "paperplane.fill")
                     .font(.title3.bold())
-                    .foregroundStyle(.white)
+                    .foregroundStyle(Color.white)
                     .padding(12)
                     .background(Circle().fill(Color.accentColor))
             }

--- a/ios/AITIExplorer/Views/ChatDetailView.swift
+++ b/ios/AITIExplorer/Views/ChatDetailView.swift
@@ -1,0 +1,266 @@
+import SwiftUI
+
+struct ChatDetailView: View {
+    let agent: AgentProfile
+    @Binding var draftedMessage: String
+    var onSend: (String) -> Void
+    var pendingResponse: Bool
+    var onShowSearch: () -> Void
+
+    @Namespace private var bottomID
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ChatHeaderView(agent: agent, onShowSearch: onShowSearch)
+
+            Divider()
+                .background(.white.opacity(0.1))
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        ForEach(agent.conversation.messages) { message in
+                            ChatBubble(message: message, agent: agent)
+                                .padding(.horizontal)
+                        }
+
+                        if pendingResponse {
+                            TypingIndicatorView()
+                                .padding(.horizontal)
+                        }
+
+                        Color.clear
+                            .frame(height: 1)
+                            .id(bottomID)
+                    }
+                    .padding(.vertical, 24)
+                }
+                .background(Color(.systemBackground))
+                .onChange(of: agent.conversation.messages.count) { _ in
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        proxy.scrollTo(bottomID, anchor: .bottom)
+                    }
+                }
+            }
+
+            Divider()
+
+            MessageComposer(text: $draftedMessage, onSend: onSend)
+                .padding()
+                .background(.thinMaterial)
+        }
+        .ignoresSafeArea(.keyboard)
+    }
+}
+
+private struct ChatHeaderView: View {
+    let agent: AgentProfile
+    var onShowSearch: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(.ultraThinMaterial)
+                    .frame(width: 72, height: 72)
+                Image(systemName: agent.avatarSystemName)
+                    .font(.largeTitle)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(agent.name)
+                    .font(.title3.bold())
+                Text(agent.role)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Label(agent.status.description, systemImage: statusIcon)
+                    .font(.caption)
+                    .foregroundStyle(statusColor)
+            }
+
+            Spacer()
+
+            Button(action: onShowSearch) {
+                Image(systemName: "magnifyingglass")
+                    .font(.title3)
+                    .padding(10)
+                    .background(.ultraThinMaterial)
+                    .clipShape(Circle())
+            }
+        }
+        .padding([.horizontal, .top])
+        .padding(.bottom, 12)
+    }
+
+    private var statusIcon: String {
+        switch agent.status {
+        case .online:
+            return "circle.fill"
+        case .offline:
+            return "circle"
+        case .busy:
+            return "clock.fill"
+        }
+    }
+
+    private var statusColor: Color {
+        switch agent.status {
+        case .online:
+            return .green
+        case .offline:
+            return .gray
+        case .busy:
+            return .orange
+        }
+    }
+}
+
+private struct ChatBubble: View {
+    let message: ChatMessage
+    let agent: AgentProfile
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 12) {
+            if message.author == .agent {
+                avatar
+            } else {
+                Spacer(minLength: 48)
+            }
+
+            VStack(alignment: message.author == .agent ? .leading : .trailing, spacing: 10) {
+                Text(message.content)
+                    .padding(16)
+                    .foregroundStyle(message.author == .agent ? .primary : .white)
+                    .background(bubbleBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+                if !message.attachments.isEmpty {
+                    AttachmentList(attachments: message.attachments)
+                }
+
+                Text(message.timeLabel)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if message.author == .user {
+                avatar
+            } else {
+                Spacer(minLength: 48)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: message.author == .agent ? .leading : .trailing)
+    }
+
+    private var avatar: some View {
+        ZStack {
+            Circle()
+                .fill(.ultraThinMaterial)
+                .frame(width: 36, height: 36)
+            Image(systemName: message.author == .agent ? agent.avatarSystemName : "person.fill")
+                .font(.subheadline)
+        }
+    }
+
+    private var bubbleBackground: some ShapeStyle {
+        if message.author == .agent {
+            return AnyShapeStyle(.thinMaterial)
+        } else {
+            return AnyShapeStyle(LinearGradient(colors: [.blue, .purple], startPoint: .topLeading, endPoint: .bottomTrailing))
+        }
+    }
+}
+
+private struct AttachmentList: View {
+    let attachments: [ChatAttachment]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(attachments) { attachment in
+                HStack {
+                    Image(systemName: attachment.kind.iconName)
+                        .foregroundStyle(.secondary)
+                    VStack(alignment: .leading) {
+                        Text(attachment.name)
+                            .font(.subheadline)
+                            .foregroundStyle(.primary)
+                        Text("\(attachment.formattedSize) • \(attachment.type)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if let duration = attachment.durationSeconds {
+                        Text("\(duration) s")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(12)
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            }
+        }
+    }
+}
+
+private struct TypingIndicatorView: View {
+    @State private var animate = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(.thinMaterial)
+                .frame(width: 36, height: 36)
+                .overlay(Image(systemName: "bolt.horizontal.fill").font(.subheadline))
+
+            HStack(spacing: 6) {
+                ForEach(0..<3) { index in
+                    Circle()
+                        .fill(.secondary)
+                        .frame(width: 8, height: 8)
+                        .scaleEffect(animate ? 1.0 : 0.4)
+                        .animation(.easeInOut(duration: 0.6).repeatForever().delay(Double(index) * 0.12), value: animate)
+                }
+            }
+        }
+        .padding(16)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .onAppear { animate = true }
+    }
+}
+
+private struct MessageComposer: View {
+    @Binding var text: String
+    var onSend: (String) -> Void
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 12) {
+            TextEditor(text: $text)
+                .frame(minHeight: 44, maxHeight: 120)
+                .padding(12)
+                .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
+
+            Button {
+                onSend(text)
+            } label: {
+                Image(systemName: "paperplane.fill")
+                    .font(.title3.bold())
+                    .foregroundStyle(.white)
+                    .padding(12)
+                    .background(Circle().fill(Color.accentColor))
+            }
+            .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+}
+
+#Preview {
+    ChatDetailView(
+        agent: SampleData.previewUser.agents.first!,
+        draftedMessage: .constant(""),
+        onSend: { _ in },
+        pendingResponse: true,
+        onShowSearch: {}
+    )
+}

--- a/ios/AITIExplorer/Views/MainTabView.swift
+++ b/ios/AITIExplorer/Views/MainTabView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct MainTabView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        TabView(selection: $appState.selectedTab) {
+            ChatContainerView()
+                .tabItem {
+                    Label("Chat", systemImage: "message.fill")
+                }
+                .tag(AppState.Tab.chat)
+
+            SettingsScreen()
+                .tabItem {
+                    Label("Einstellungen", systemImage: "gear")
+                }
+                .tag(AppState.Tab.settings)
+
+            ProfileScreen()
+                .tabItem {
+                    Label("Profil", systemImage: "person.crop.circle")
+                }
+                .tag(AppState.Tab.profile)
+        }
+        .tint(appState.settings.accentColor.color)
+        .preferredColorScheme(appState.settings.colorScheme.preferredScheme)
+    }
+}
+
+#Preview {
+    MainTabView()
+        .environmentObject(AppState(previewUser: SampleData.previewUser))
+}

--- a/ios/AITIExplorer/Views/ProfileScreen.swift
+++ b/ios/AITIExplorer/Views/ProfileScreen.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+
+struct ProfileScreen: View {
+    @EnvironmentObject private var appState: AppState
+    @StateObject private var viewModel = ProfileViewModel()
+    @State private var newAgentName: String = ""
+    @State private var newAgentRole: String = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                profileSection
+                agentSection
+                sessionSection
+            }
+            .navigationTitle("Profil")
+        }
+        .toast(message: viewModel.toastMessage, isPresented: Binding(
+            get: { viewModel.toastMessage != nil },
+            set: { newValue in if !newValue { viewModel.toastMessage = nil } }
+        ))
+        .onAppear {
+            viewModel.attach(appState: appState)
+        }
+    }
+
+    private var profileSection: some View {
+        Section(header: Text("Dein Profil")) {
+            TextField("Name", text: $viewModel.draftName)
+            TextField("Bio", text: $viewModel.draftBio, axis: .vertical)
+                .lineLimit(2...5)
+            Toggle("Aktiv", isOn: $viewModel.isActive)
+
+            Button("Profil speichern") {
+                viewModel.saveProfile()
+            }
+        }
+    }
+
+    private var agentSection: some View {
+        Section(header: Text("Agents"), footer: Text("Aktiviere oder deaktiviere Agents, um ihren Status zu simulieren.")) {
+            ForEach(viewModel.agents) { agent in
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text(agent.name)
+                        Text(agent.role)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Menu {
+                        Button(agent.status == .online ? "Als offline markieren" : "Als online markieren") {
+                            viewModel.toggleAgent(agent)
+                        }
+                        Button("Agent entfernen", role: .destructive) {
+                            viewModel.removeAgent(agent)
+                        }
+                    } label: {
+                        Label(agent.status.description, systemImage: agent.status == .online ? "checkmark.circle.fill" : "clock")
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("Agent Name", text: $newAgentName)
+                TextField("Rolle", text: $newAgentRole)
+                Button("Agent hinzufügen") {
+                    viewModel.addAgent(name: newAgentName, role: newAgentRole)
+                    newAgentName = ""
+                    newAgentRole = ""
+                }
+                .disabled(newAgentName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+
+    private var sessionSection: some View {
+        Section {
+            Button("Abmelden", role: .destructive) {
+                appState.logout()
+            }
+        }
+    }
+}
+
+private struct ToastModifier: ViewModifier {
+    let message: String
+    @Binding var isPresented: Bool
+
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            if isPresented {
+                VStack {
+                    Spacer()
+                    Text(message)
+                        .padding()
+                        .background(.thinMaterial)
+                        .clipShape(Capsule())
+                        .shadow(radius: 8)
+                        .padding()
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(.spring(), value: isPresented)
+    }
+}
+
+private extension View {
+    func toast(message: String?, isPresented: Binding<Bool>) -> some View {
+        modifier(ToastModifier(message: message ?? "", isPresented: isPresented))
+    }
+}
+
+#Preview {
+    ProfileScreen()
+        .environmentObject(AppState(previewUser: SampleData.previewUser))
+}

--- a/ios/AITIExplorer/Views/RootView.swift
+++ b/ios/AITIExplorer/Views/RootView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        Group {
+            if appState.currentUser != nil {
+                MainTabView()
+            } else {
+                AuthView()
+            }
+        }
+        .animation(.easeInOut, value: appState.currentUser)
+    }
+}
+
+#Preview {
+    RootView()
+        .environmentObject(AppState(previewUser: SampleData.previewUser))
+}

--- a/ios/AITIExplorer/Views/SearchResultsView.swift
+++ b/ios/AITIExplorer/Views/SearchResultsView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct SearchResultsView: View {
+    @Binding var query: String
+    let results: [ChatMessage]
+    let isSearching: Bool
+
+    var body: some View {
+        List {
+            Section(header: Text("Suche")) {
+                TextField("Nachrichten durchsuchen", text: $query)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            Section(header: Text("Ergebnisse")) {
+                if isSearching && results.isEmpty {
+                    ProgressView("Suche läuft …")
+                        .frame(maxWidth: .infinity)
+                } else if results.isEmpty {
+                    ContentUnavailableView.search
+                } else {
+                    ForEach(results) { message in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(message.content)
+                                .font(.body)
+                                .foregroundStyle(.primary)
+                                .lineLimit(4)
+
+                            Text(message.timeLabel)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Chat durchsuchen")
+    }
+}
+
+#Preview {
+    SearchResultsView(
+        query: .constant("Launch"),
+        results: SampleData.previewUser.agents.first!.conversation.messages,
+        isSearching: false
+    )
+}

--- a/ios/AITIExplorer/Views/SettingsScreen.swift
+++ b/ios/AITIExplorer/Views/SettingsScreen.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+struct SettingsScreen: View {
+    @EnvironmentObject private var appState: AppState
+    @StateObject private var viewModel = SettingsViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                appearanceSection
+                preferencesSection
+                webhookSection
+            }
+            .navigationTitle("Einstellungen")
+            .toolbar { toolbarItems }
+            .alert("Webhook Test", isPresented: isTestingWebhookBinding) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(viewModel.webhookMessage ?? "")
+            }
+        }
+        .onAppear {
+            viewModel.attach(appState: appState)
+        }
+    }
+
+    private var isTestingWebhookBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.webhookTestStatus == .success || viewModel.webhookTestStatus == .failure },
+            set: { _ in viewModel.webhookTestStatus = .idle }
+        )
+    }
+
+    private var appearanceSection: some View {
+        Section(header: Text("Darstellung")) {
+            Picker("Farbschema", selection: $viewModel.settings.colorScheme) {
+                ForEach(ColorSchemeOption.allCases) { option in
+                    Text(option.title).tag(option)
+                }
+            }
+
+            Picker("Akzentfarbe", selection: $viewModel.settings.accentColor) {
+                ForEach(AccentColorOption.allCases) { option in
+                    HStack {
+                        Circle()
+                            .fill(option.color)
+                            .frame(width: 16, height: 16)
+                        Text(option.title)
+                    }
+                    .tag(option)
+                }
+            }
+        }
+    }
+
+    private var preferencesSection: some View {
+        Section(header: Text("Chat Verhalten")) {
+            Toggle("Sende-Sound abspielen", isOn: $viewModel.settings.playSendSound)
+            Toggle("Typing-Indikator anzeigen", isOn: $viewModel.settings.showTypingIndicator)
+            Toggle("Kompaktes Layout", isOn: $viewModel.settings.preferCompactLayout)
+
+            TextField("Notizen", text: $viewModel.settings.notes, axis: .vertical)
+                .lineLimit(3...6)
+        }
+    }
+
+    private var webhookSection: some View {
+        Section(header: Text("Webhook"), footer: Text("Nutze Webhooks, um externe Systeme mit Antworten deiner Agents zu versorgen.")) {
+            TextField("https://hooks.example.com", text: Binding(
+                get: { viewModel.settings.webhookURL?.absoluteString ?? "" },
+                set: { viewModel.settings.webhookURL = URL(string: $0) }
+            ))
+            .keyboardType(.URL)
+            .textInputAutocapitalization(.never)
+
+            Button("Webhook testen") {
+                viewModel.testWebhook()
+            }
+        }
+    }
+
+    private var toolbarItems: some ToolbarContent {
+        ToolbarItemGroup(placement: .navigationBarTrailing) {
+            if viewModel.saveStatus == .inProgress {
+                ProgressView()
+            }
+            Button("Zurücksetzen") {
+                viewModel.reset()
+            }
+            Button("Speichern") {
+                viewModel.save()
+            }
+            .disabled(viewModel.saveStatus == .inProgress)
+        }
+    }
+}
+
+#Preview {
+    SettingsScreen()
+        .environmentObject(AppState(previewUser: SampleData.previewUser))
+}

--- a/ios/SETUP_GUIDE.md
+++ b/ios/SETUP_GUIDE.md
@@ -1,0 +1,52 @@
+# AITI Explorer iOS – Setup-Anleitung
+
+Diese Anleitung beschreibt, wie du das neue SwiftUI-Projekt in Xcode anlegst, die bereitgestellten Dateien einbindest und die App anschließend auf einem Simulator oder Gerät testest.
+
+## 1. Neues Xcode-Projekt erstellen
+1. Öffne **Xcode 15** (oder neuer) und wähle im Startdialog **Create a new Xcode project**.
+2. Wähle unter *iOS* die Vorlage **App** aus und klicke auf **Next**.
+3. Vergib einen Produktnamen, z. B. `AITIExplorer`.
+4. Stelle folgende Optionen ein:
+   - **Team**: (dein Apple-Entwicklerteam oder „None“ für den Simulator)
+   - **Organization Identifier**: z. B. `ai.aiti`
+   - **Interface**: `SwiftUI`
+   - **Language**: `Swift`
+   - **Use Core Data**: deaktiviert
+   - **Include Tests**: optional
+5. Wähle einen Speicherort und bestätige mit **Create**.
+
+## 2. Projektstruktur anlegen
+1. Erstelle in Xcode in der Projekt-Navigator-Leiste die folgenden Gruppen (Ordner):
+   - `Models`
+   - `ViewModels`
+   - `Views`
+   - `Resources`
+2. Ziehe die Dateien aus diesem Repository (`ios/AITIExplorer/...`) per Drag & Drop in die entsprechenden Gruppen:
+   - `AITIExplorerApp.swift` und `Views/RootView.swift` in die Hauptebene deines Projekts.
+   - Dateien in `Models`, `ViewModels`, `Views` und `Resources` jeweils in die gleichnamigen Gruppen.
+3. Achte darauf, dass **Copy items if needed** aktiviert ist und die Ziel-Targets deiner App ausgewählt sind.
+
+## 3. Assets & App Icon
+- Die aktuelle Implementierung nutzt ausschließlich SF Symbols und systemeigene Farben. Du kannst deshalb zunächst auf eigene Assets verzichten.
+- Optional kannst du in der *Assets*-Sektion von Xcode ein App-Icon hinzufügen.
+
+## 4. App starten
+1. Wähle im Scheme-Menü den gewünschten Simulator (z. B. *iPhone 15 Pro*).
+2. Baue und starte die App mit `⌘R`.
+3. Melde dich mit dem Demo-Zugang an:
+   - **E-Mail:** `demo@aiti.ai`
+   - **Passwort:** `SwiftRocks!`
+4. Navigiere über die Tab-Leiste zwischen **Chat**, **Einstellungen** und **Profil**.
+
+## 5. Eigene Erweiterungen
+- Passe Daten im `SampleData.swift` an, um weitere Agents oder Nachrichten hinzuzufügen.
+- Über die `Profile`-Ansicht kannst du neue Agents direkt in der App anlegen.
+- Der Einstellungen-Tab speichert gewählte Optionen via `UserDefaults` (`SampleData.saveSettings`).
+
+## 6. Optional: Testen auf einem Gerät
+1. Verbinde dein iPhone via USB oder WLAN mit dem Mac.
+2. Wähle das Gerät als Run Destination aus.
+3. Signiere das Projekt mit deinem Entwicklerprofil (unter **Signing & Capabilities**).
+4. Starte die App mit `⌘R`.
+
+Viel Erfolg beim Testen der nativen iOS-Version des AITI Explorer Agents!


### PR DESCRIPTION
## Summary
- add a SwiftUI-based iOS implementation with chat, settings, and profile tabs
- provide view models, sample data, and authentication logic for the native app experience
- document detailed setup steps for integrating the new code into an Xcode project

## Testing
- not run (Swift code)


------
https://chatgpt.com/codex/tasks/task_e_68efe0a85f088324ae37fa54c9432611